### PR TITLE
[codex] Compile glmnet path chunks

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,8 @@
 
 * Reworked `mlxs_glmnet()` to use dense on-device MLX updates, removing the
   active-set slicing/scatter hotspot from the Gaussian and binomial paths.
+* Added a Gaussian covariance-space path for very tall problems, so
+  `mlxs_glmnet()` can reuse `X'X / n` when `n` is much larger than `p`.
 * Export `mlxs_lm_fit()` so advanced users can call the MLX-backed QR solver directly.
 
 # RmlxStats 0.1.0

--- a/NEWS.md
+++ b/NEWS.md
@@ -4,6 +4,8 @@
   active-set slicing/scatter hotspot from the Gaussian and binomial paths.
 * Added a Gaussian covariance-space path for very tall problems, so
   `mlxs_glmnet()` can reuse `X'X / n` when `n` is much larger than `p`.
+* Cache `mlx_compile()`'d chunk updates inside `mlxs_glmnet()`, cutting the
+  host overhead for Gaussian and binomial path iterations.
 * Export `mlxs_lm_fit()` so advanced users can call the MLX-backed QR solver directly.
 
 # RmlxStats 0.1.0

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # RmlxStats (development version)
 
+* Reworked `mlxs_glmnet()` to use dense on-device MLX updates, removing the
+  active-set slicing/scatter hotspot from the Gaussian and binomial paths.
 * Export `mlxs_lm_fit()` so advanced users can call the MLX-backed QR solver directly.
 
 # RmlxStats 0.1.0

--- a/R/mlxs-glmnet-compiled.R
+++ b/R/mlxs-glmnet-compiled.R
@@ -1,10 +1,21 @@
 # Compiled inner loop for mlxs_glmnet
 # Separated out to enable mlx_compile() optimization
 
-.mlxs_glmnet_one_iteration <- function(x_active, beta_prev_subset, residual_mlx,
-                                       intercept_prev, eta_mlx, y_mlx, ones_mlx,
-                                       n_obs, step, lambda_val, alpha, thresh,
-                                       is_gaussian_flag) {
+.mlxs_glmnet_one_iteration <- function(
+  x_active,
+  beta_prev_subset,
+  residual_mlx,
+  intercept_prev,
+  eta_mlx,
+  y_mlx,
+  ones_mlx,
+  n_obs,
+  step,
+  lambda_val,
+  alpha,
+  thresh,
+  is_gaussian_flag
+) {
   # Gradient computation
   grad_active <- crossprod(x_active, residual_mlx) / n_obs
 
@@ -57,13 +68,20 @@
 .get_compiled_iteration <- function() {
   if (is.null(.mlxs_glmnet_cache$compiled)) {
     # Try to compile, fall back to uncompiled if it fails
-    .mlxs_glmnet_cache$compiled <- tryCatch({
-      Rmlx::mlx_compile(.mlxs_glmnet_one_iteration)
-    }, error = function(e) {
-      warning("Could not compile mlxs_glmnet inner loop: ", conditionMessage(e),
-              "\nUsing uncompiled version (slower).", call. = FALSE)
-      .mlxs_glmnet_one_iteration
-    })
+    .mlxs_glmnet_cache$compiled <- tryCatch(
+      {
+        Rmlx::mlx_compile(.mlxs_glmnet_one_iteration)
+      },
+      error = function(e) {
+        warning(
+          "Could not compile mlxs_glmnet inner loop: ",
+          conditionMessage(e),
+          "\nUsing uncompiled version (slower).",
+          call. = FALSE
+        )
+        .mlxs_glmnet_one_iteration
+      }
+    )
   }
   .mlxs_glmnet_cache$compiled
 }

--- a/R/mlxs-glmnet-compiled.R
+++ b/R/mlxs-glmnet-compiled.R
@@ -1,69 +1,89 @@
-# Compiled inner loop for mlxs_glmnet
-# Separated out to enable mlx_compile() optimization
+.mlxs_glmnet_gaussian_chunk <- function(x_mlx,
+                                        beta_mlx,
+                                        eta_mlx,
+                                        residual_mlx,
+                                        y_mlx,
+                                        n_obs,
+                                        step,
+                                        thresh,
+                                        ridge_penalty,
+                                        n_steps) {
+  delta_max <- Rmlx::mlx_scalar(0)
 
-.mlxs_glmnet_one_iteration <- function(x_active, beta_prev_subset, residual_mlx,
-                                       intercept_prev, eta_mlx, y_mlx, ones_mlx,
-                                       n_obs, step, lambda_val, alpha, thresh,
-                                       is_gaussian_flag) {
-  # Gradient computation
-  grad_active <- crossprod(x_active, residual_mlx) / n_obs
+  for (i in seq_len(n_steps)) {
+    grad_mlx <- crossprod(x_mlx, residual_mlx) / n_obs
+    if (ridge_penalty != 0) {
+      grad_mlx <- grad_mlx + beta_mlx * ridge_penalty
+    }
 
-  # Ridge penalty (always compute, will be zero if alpha=1)
-  grad_active <- grad_active + beta_prev_subset * (lambda_val * (1 - alpha))
+    beta_new_mlx <- .mlxs_soft_threshold(beta_mlx - step * grad_mlx, thresh)
+    delta_mlx <- beta_new_mlx - beta_mlx
 
-  # Proximal gradient step
-  beta_temp <- beta_prev_subset - grad_active * step
+    eta_mlx <- eta_mlx + x_mlx %*% delta_mlx
+    residual_mlx <- eta_mlx - y_mlx
+    beta_mlx <- beta_new_mlx
 
-  # Soft threshold
-  abs_beta <- abs(beta_temp)
-  magnitude <- Rmlx::mlx_maximum(abs_beta - thresh, 0)
-  sign_beta <- beta_temp / (abs_beta + 1e-10)
-  beta_new_subset <- magnitude * sign_beta
+    delta_max <- Rmlx::mlx_maximum(delta_max, max(abs(delta_mlx)))
+  }
 
-  delta_beta <- beta_new_subset - beta_prev_subset
-
-  # Intercept update
-  residual_sum <- Rmlx::mlx_sum(residual_mlx)
-  intercept_grad <- residual_sum / n_obs
-  intercept_delta <- intercept_grad * step
-  intercept_new <- intercept_prev - intercept_delta
-
-  # Update eta
-  eta_new <- eta_mlx + x_active %*% delta_beta - ones_mlx * intercept_delta
-
-  # Link inverse (gaussian: identity, binomial: logistic)
-  # is_gaussian_flag is 1 for gaussian, 0 for binomial
-  mu_binomial <- 1 / (1 + exp(-eta_new))
-  mu <- Rmlx::mlx_where(is_gaussian_flag > 0.5, eta_new, mu_binomial)
-
-  residual_new <- mu - y_mlx
-
-  # Return list with named elements (Rmlx issue #16 now fixed)
   list(
-    beta_new = beta_new_subset,
-    delta_beta = delta_beta,
-    intercept_new = intercept_new,
-    intercept_delta = intercept_delta,
-    eta_new = eta_new,
-    residual_new = residual_new
+    beta = beta_mlx,
+    eta = eta_mlx,
+    residual = residual_mlx,
+    delta_max = delta_max
   )
 }
 
-# Environment to cache compiled version (avoids locked binding issues)
-.mlxs_glmnet_cache <- new.env(parent = emptyenv())
-.mlxs_glmnet_cache$compiled <- NULL
+.mlxs_glmnet_binomial_chunk <- function(x_mlx,
+                                        beta_mlx,
+                                        intercept_mlx,
+                                        eta_mlx,
+                                        residual_mlx,
+                                        y_mlx,
+                                        ones_mlx,
+                                        n_obs,
+                                        step,
+                                        thresh,
+                                        ridge_penalty,
+                                        n_steps,
+                                        fit_intercept) {
+  delta_max <- Rmlx::mlx_scalar(0)
+  intercept_delta_max <- Rmlx::mlx_scalar(0)
 
-# Initialize compiled version (called on first use)
-.get_compiled_iteration <- function() {
-  if (is.null(.mlxs_glmnet_cache$compiled)) {
-    # Try to compile, fall back to uncompiled if it fails
-    .mlxs_glmnet_cache$compiled <- tryCatch({
-      Rmlx::mlx_compile(.mlxs_glmnet_one_iteration)
-    }, error = function(e) {
-      warning("Could not compile mlxs_glmnet inner loop: ", conditionMessage(e),
-              "\nUsing uncompiled version (slower).", call. = FALSE)
-      .mlxs_glmnet_one_iteration
-    })
+  for (i in seq_len(n_steps)) {
+    grad_mlx <- crossprod(x_mlx, residual_mlx) / n_obs
+    if (ridge_penalty != 0) {
+      grad_mlx <- grad_mlx + beta_mlx * ridge_penalty
+    }
+
+    beta_new_mlx <- .mlxs_soft_threshold(beta_mlx - step * grad_mlx, thresh)
+    delta_mlx <- beta_new_mlx - beta_mlx
+
+    if (fit_intercept) {
+      intercept_delta_mlx <- step * (Rmlx::mlx_sum(residual_mlx) / n_obs)
+      intercept_mlx <- intercept_mlx - intercept_delta_mlx
+      eta_mlx <- eta_mlx + x_mlx %*% delta_mlx - ones_mlx * intercept_delta_mlx
+      intercept_delta_max <- Rmlx::mlx_maximum(
+        intercept_delta_max,
+        abs(intercept_delta_mlx)
+      )
+    } else {
+      eta_mlx <- eta_mlx + x_mlx %*% delta_mlx
+    }
+
+    mu_mlx <- 1 / (1 + exp(-eta_mlx))
+    residual_mlx <- mu_mlx - y_mlx
+    beta_mlx <- beta_new_mlx
+
+    delta_max <- Rmlx::mlx_maximum(delta_max, max(abs(delta_mlx)))
   }
-  .mlxs_glmnet_cache$compiled
+
+  list(
+    beta = beta_mlx,
+    intercept = intercept_mlx,
+    eta = eta_mlx,
+    residual = residual_mlx,
+    delta_max = delta_max,
+    intercept_delta_max = intercept_delta_max
+  )
 }

--- a/R/mlxs-glmnet-compiled.R
+++ b/R/mlxs-glmnet-compiled.R
@@ -122,3 +122,174 @@
     intercept_delta_max = intercept_delta_max
   )
 }
+
+.mlxs_glmnet_chunk_cache <- new.env(parent = emptyenv())
+
+.mlxs_glmnet_chunk_key <- function(kind,
+                                   n_steps,
+                                   fit_intercept = NULL) {
+  if (is.null(fit_intercept)) {
+    paste(kind, n_steps, sep = "::")
+  } else {
+    paste(kind, n_steps, fit_intercept, sep = "::")
+  }
+}
+
+.mlxs_glmnet_get_compiled_chunk <- function(kind,
+                                            n_steps,
+                                            fit_intercept = NULL) {
+  key <- .mlxs_glmnet_chunk_key(kind, n_steps, fit_intercept)
+  if (!exists(key, envir = .mlxs_glmnet_chunk_cache, inherits = FALSE)) {
+    chunk_fn <- switch(
+      kind,
+      gaussian = .mlxs_glmnet_make_gaussian_compiled_chunk(n_steps),
+      gaussian_gram = .mlxs_glmnet_make_gaussian_gram_compiled_chunk(n_steps),
+      binomial = .mlxs_glmnet_make_binomial_compiled_chunk(
+        n_steps = n_steps,
+        fit_intercept = fit_intercept
+      ),
+      stop("Unknown chunk kind: ", kind, call. = FALSE)
+    )
+    assign(key, chunk_fn, envir = .mlxs_glmnet_chunk_cache)
+  }
+  get(key, envir = .mlxs_glmnet_chunk_cache, inherits = FALSE)
+}
+
+.mlxs_glmnet_make_gaussian_compiled_chunk <- function(n_steps) {
+  Rmlx::mlx_compile(function(x_mlx,
+                             beta_mlx,
+                             eta_mlx,
+                             residual_mlx,
+                             y_mlx,
+                             n_obs_mlx,
+                             step_mlx,
+                             thresh_mlx,
+                             ridge_penalty_mlx,
+                             zero_mlx) {
+    delta_max <- zero_mlx
+
+    for (i in seq_len(n_steps)) {
+      grad_mlx <- crossprod(x_mlx, residual_mlx) / n_obs_mlx
+      grad_mlx <- grad_mlx + beta_mlx * ridge_penalty_mlx
+
+      beta_new_mlx <- .mlxs_soft_threshold(
+        beta_mlx - step_mlx * grad_mlx,
+        thresh_mlx
+      )
+      delta_mlx <- beta_new_mlx - beta_mlx
+
+      eta_mlx <- eta_mlx + x_mlx %*% delta_mlx
+      residual_mlx <- eta_mlx - y_mlx
+      beta_mlx <- beta_new_mlx
+
+      delta_max <- Rmlx::mlx_maximum(delta_max, max(abs(delta_mlx)))
+    }
+
+    list(
+      beta = beta_mlx,
+      eta = eta_mlx,
+      residual = residual_mlx,
+      delta_max = delta_max
+    )
+  })
+}
+
+.mlxs_glmnet_make_gaussian_gram_compiled_chunk <- function(n_steps) {
+  Rmlx::mlx_compile(function(gram_mlx,
+                             xy_mlx,
+                             beta_mlx,
+                             z_mlx,
+                             t_prev_mlx,
+                             step_mlx,
+                             thresh_mlx,
+                             ridge_penalty_mlx,
+                             zero_mlx,
+                             one_mlx,
+                             four_mlx) {
+    delta_max <- zero_mlx
+    t_prev_local <- t_prev_mlx
+
+    for (i in seq_len(n_steps)) {
+      grad_mlx <- gram_mlx %*% z_mlx - xy_mlx
+      grad_mlx <- grad_mlx + z_mlx * ridge_penalty_mlx
+
+      beta_new_mlx <- .mlxs_soft_threshold(
+        z_mlx - step_mlx * grad_mlx,
+        thresh_mlx
+      )
+      delta_mlx <- beta_new_mlx - beta_mlx
+      delta_max <- Rmlx::mlx_maximum(delta_max, max(abs(delta_mlx)))
+
+      t_next <- (one_mlx + sqrt(one_mlx + four_mlx * t_prev_local^2)) / 2
+      z_mlx <- beta_new_mlx + ((t_prev_local - one_mlx) / t_next) * delta_mlx
+      beta_mlx <- beta_new_mlx
+      t_prev_local <- t_next
+    }
+
+    list(
+      beta = beta_mlx,
+      z = z_mlx,
+      t_prev = t_prev_local,
+      delta_max = delta_max
+    )
+  })
+}
+
+.mlxs_glmnet_make_binomial_compiled_chunk <- function(n_steps,
+                                                      fit_intercept) {
+  Rmlx::mlx_compile(function(x_mlx,
+                             beta_mlx,
+                             intercept_mlx,
+                             eta_mlx,
+                             residual_mlx,
+                             y_mlx,
+                             ones_mlx,
+                             n_obs_mlx,
+                             step_mlx,
+                             thresh_mlx,
+                             ridge_penalty_mlx,
+                             zero_mlx) {
+    delta_max <- zero_mlx
+    intercept_delta_max <- zero_mlx
+
+    for (i in seq_len(n_steps)) {
+      grad_mlx <- crossprod(x_mlx, residual_mlx) / n_obs_mlx
+      grad_mlx <- grad_mlx + beta_mlx * ridge_penalty_mlx
+
+      beta_new_mlx <- .mlxs_soft_threshold(
+        beta_mlx - step_mlx * grad_mlx,
+        thresh_mlx
+      )
+      delta_mlx <- beta_new_mlx - beta_mlx
+
+      if (fit_intercept) {
+        intercept_delta_mlx <- step_mlx * (Rmlx::mlx_sum(residual_mlx) /
+          n_obs_mlx)
+        intercept_mlx <- intercept_mlx - intercept_delta_mlx
+        eta_mlx <- eta_mlx + x_mlx %*% delta_mlx -
+          ones_mlx * intercept_delta_mlx
+        intercept_delta_max <- Rmlx::mlx_maximum(
+          intercept_delta_max,
+          abs(intercept_delta_mlx)
+        )
+      } else {
+        eta_mlx <- eta_mlx + x_mlx %*% delta_mlx
+      }
+
+      mu_mlx <- 1 / (1 + exp(-eta_mlx))
+      residual_mlx <- mu_mlx - y_mlx
+      beta_mlx <- beta_new_mlx
+
+      delta_max <- Rmlx::mlx_maximum(delta_max, max(abs(delta_mlx)))
+    }
+
+    list(
+      beta = beta_mlx,
+      intercept = intercept_mlx,
+      eta = eta_mlx,
+      residual = residual_mlx,
+      delta_max = delta_max,
+      intercept_delta_max = intercept_delta_max
+    )
+  })
+}

--- a/R/mlxs-glmnet-compiled.R
+++ b/R/mlxs-glmnet-compiled.R
@@ -1,21 +1,10 @@
 # Compiled inner loop for mlxs_glmnet
 # Separated out to enable mlx_compile() optimization
 
-.mlxs_glmnet_one_iteration <- function(
-  x_active,
-  beta_prev_subset,
-  residual_mlx,
-  intercept_prev,
-  eta_mlx,
-  y_mlx,
-  ones_mlx,
-  n_obs,
-  step,
-  lambda_val,
-  alpha,
-  thresh,
-  is_gaussian_flag
-) {
+.mlxs_glmnet_one_iteration <- function(x_active, beta_prev_subset, residual_mlx,
+                                       intercept_prev, eta_mlx, y_mlx, ones_mlx,
+                                       n_obs, step, lambda_val, alpha, thresh,
+                                       is_gaussian_flag) {
   # Gradient computation
   grad_active <- crossprod(x_active, residual_mlx) / n_obs
 
@@ -68,20 +57,13 @@
 .get_compiled_iteration <- function() {
   if (is.null(.mlxs_glmnet_cache$compiled)) {
     # Try to compile, fall back to uncompiled if it fails
-    .mlxs_glmnet_cache$compiled <- tryCatch(
-      {
-        Rmlx::mlx_compile(.mlxs_glmnet_one_iteration)
-      },
-      error = function(e) {
-        warning(
-          "Could not compile mlxs_glmnet inner loop: ",
-          conditionMessage(e),
-          "\nUsing uncompiled version (slower).",
-          call. = FALSE
-        )
-        .mlxs_glmnet_one_iteration
-      }
-    )
+    .mlxs_glmnet_cache$compiled <- tryCatch({
+      Rmlx::mlx_compile(.mlxs_glmnet_one_iteration)
+    }, error = function(e) {
+      warning("Could not compile mlxs_glmnet inner loop: ", conditionMessage(e),
+              "\nUsing uncompiled version (slower).", call. = FALSE)
+      .mlxs_glmnet_one_iteration
+    })
   }
   .mlxs_glmnet_cache$compiled
 }

--- a/R/mlxs-glmnet-compiled.R
+++ b/R/mlxs-glmnet-compiled.R
@@ -34,6 +34,41 @@
   )
 }
 
+.mlxs_glmnet_gaussian_gram_chunk <- function(gram_mlx,
+                                             xy_mlx,
+                                             beta_mlx,
+                                             z_mlx,
+                                             t_prev,
+                                             step,
+                                             thresh,
+                                             ridge_penalty,
+                                             n_steps) {
+  delta_max <- Rmlx::mlx_scalar(0)
+
+  for (i in seq_len(n_steps)) {
+    grad_mlx <- gram_mlx %*% z_mlx - xy_mlx
+    if (ridge_penalty != 0) {
+      grad_mlx <- grad_mlx + z_mlx * ridge_penalty
+    }
+
+    beta_new_mlx <- .mlxs_soft_threshold(z_mlx - step * grad_mlx, thresh)
+    delta_mlx <- beta_new_mlx - beta_mlx
+    delta_max <- Rmlx::mlx_maximum(delta_max, max(abs(delta_mlx)))
+
+    t_next <- (1 + sqrt(1 + 4 * t_prev^2)) / 2
+    z_mlx <- beta_new_mlx + ((t_prev - 1) / t_next) * delta_mlx
+    beta_mlx <- beta_new_mlx
+    t_prev <- t_next
+  }
+
+  list(
+    beta = beta_mlx,
+    z = z_mlx,
+    t_prev = t_prev,
+    delta_max = delta_max
+  )
+}
+
 .mlxs_glmnet_binomial_chunk <- function(x_mlx,
                                         beta_mlx,
                                         intercept_mlx,

--- a/R/mlxs-glmnet.R
+++ b/R/mlxs-glmnet.R
@@ -6,7 +6,9 @@
 #'
 #' @note This implementation uses dense MLX updates rather than `glmnet`'s
 #'   coordinate-descent Fortran kernels, so `glmnet::glmnet()` can still be
-#'   faster on smaller problems.
+#'   faster on smaller problems. For very tall Gaussian problems, the fitter
+#'   switches to a covariance-space MLX solver to reduce repeated `X'X`
+#'   products along the path.
 #'
 #' @param x Numeric matrix of predictors (observations in rows).
 #' @param y Numeric response vector (for binomial, values must be 0/1).
@@ -75,6 +77,7 @@ mlxs_glmnet <- function(x,
       lambda = lambda,
       nlambda = nlambda,
       lambda_min_ratio = lambda_min_ratio,
+      intercept = intercept,
       maxit = maxit,
       tol = tol,
       chunk_size = chunk_size
@@ -166,12 +169,62 @@ mlxs_glmnet <- function(x,
                                       lambda,
                                       nlambda,
                                       lambda_min_ratio,
+                                      intercept,
                                       maxit,
                                       tol,
                                       chunk_size) {
   n_obs <- nrow(x_mlx)
   n_pred <- ncol(x_mlx)
-  y_mean <- mean(y)
+  n_lambda <- if (is.null(lambda)) nlambda else length(lambda)
+
+  solver <- .mlxs_glmnet_choose_gaussian_solver(
+    n_obs = n_obs,
+    n_pred = n_pred,
+    n_lambda = n_lambda
+  )
+
+  if (identical(solver, "gram")) {
+    return(.mlxs_glmnet_fit_gaussian_gram(
+      x_mlx = x_mlx,
+      y = y,
+      alpha = alpha,
+      lambda = lambda,
+      nlambda = nlambda,
+      lambda_min_ratio = lambda_min_ratio,
+      intercept = intercept,
+      maxit = maxit,
+      tol = tol,
+      chunk_size = chunk_size
+    ))
+  }
+
+  .mlxs_glmnet_fit_gaussian_dense(
+    x_mlx = x_mlx,
+    y = y,
+    alpha = alpha,
+    lambda = lambda,
+    nlambda = nlambda,
+    lambda_min_ratio = lambda_min_ratio,
+    intercept = intercept,
+    maxit = maxit,
+    tol = tol,
+    chunk_size = chunk_size
+  )
+}
+
+.mlxs_glmnet_fit_gaussian_dense <- function(x_mlx,
+                                            y,
+                                            alpha,
+                                            lambda,
+                                            nlambda,
+                                            lambda_min_ratio,
+                                            intercept,
+                                            maxit,
+                                            tol,
+                                            chunk_size) {
+  n_obs <- nrow(x_mlx)
+  n_pred <- ncol(x_mlx)
+  y_mean <- if (intercept) mean(y) else 0
   y_mlx <- Rmlx::mlx_reshape(Rmlx::as_mlx(y - y_mean), c(n_obs, 1L))
 
   lambda_max <- .mlxs_glmnet_lambda_max(x_mlx, -y_mlx, n_obs, alpha)
@@ -184,7 +237,7 @@ mlxs_glmnet <- function(x,
   residual_mlx <- -y_mlx
   beta_store_mlx <- Rmlx::mlx_zeros(c(n_pred, n_lambda))
   intercept_store_mlx <- Rmlx::mlx_zeros(c(n_lambda, 1L))
-  y_mean_mlx <- Rmlx::mlx_matrix(y_mean, nrow = 1L, ncol = 1L)
+  intercept_mlx <- Rmlx::mlx_matrix(y_mean, nrow = 1L, ncol = 1L)
 
   col_sq_sums <- as.numeric(Rmlx::colSums(x_mlx^2))
   base_lipschitz <- max(col_sq_sums) / n_obs
@@ -229,7 +282,97 @@ mlxs_glmnet <- function(x,
     )
     intercept_store_mlx <- Rmlx::mlx_slice_update(
       intercept_store_mlx,
-      y_mean_mlx,
+      intercept_mlx,
+      start = c(idx, 1L),
+      stop = c(idx, 1L)
+    )
+  }
+
+  list(
+    beta = beta_store_mlx,
+    intercept = intercept_store_mlx,
+    lambda = lambda
+  )
+}
+
+.mlxs_glmnet_fit_gaussian_gram <- function(x_mlx,
+                                           y,
+                                           alpha,
+                                           lambda,
+                                           nlambda,
+                                           lambda_min_ratio,
+                                           intercept,
+                                           maxit,
+                                           tol,
+                                           chunk_size) {
+  n_obs <- nrow(x_mlx)
+  n_pred <- ncol(x_mlx)
+  y_mean <- if (intercept) mean(y) else 0
+  y_mlx <- Rmlx::mlx_reshape(Rmlx::as_mlx(y - y_mean), c(n_obs, 1L))
+
+  gram_mlx <- crossprod(x_mlx) / n_obs
+  xy_mlx <- crossprod(x_mlx, y_mlx) / n_obs
+
+  lambda_max <- max(abs(as.numeric(xy_mlx))) / max(alpha, 1e-8)
+  if (is.finite(lambda_max) && lambda_max == 0) {
+    lambda_max <- 1
+  }
+  lambda <- .mlxs_glmnet_lambda_path(lambda, lambda_max, nlambda,
+                                     lambda_min_ratio)
+  n_lambda <- length(lambda)
+
+  beta_mlx <- Rmlx::mlx_zeros(c(n_pred, 1L))
+  z_mlx <- beta_mlx
+  t_prev <- 1
+  beta_store_mlx <- Rmlx::mlx_zeros(c(n_pred, n_lambda))
+  intercept_store_mlx <- Rmlx::mlx_zeros(c(n_lambda, 1L))
+  intercept_mlx <- Rmlx::mlx_matrix(y_mean, nrow = 1L, ncol = 1L)
+  gram_lipschitz <- as.numeric(max(Rmlx::colSums(abs(gram_mlx))))
+  effective_maxit <- min(maxit, 200L)
+
+  for (idx in seq_along(lambda)) {
+    lambda_val <- lambda[idx]
+    ridge_penalty <- lambda_val * (1 - alpha)
+    step <- 1 / (gram_lipschitz + ridge_penalty)
+    thresh <- lambda_val * alpha * step
+
+    remaining <- effective_maxit
+    z_mlx <- beta_mlx
+    t_prev <- 1
+
+    while (remaining > 0L) {
+      n_steps <- min(chunk_size, remaining)
+      state <- .mlxs_glmnet_gaussian_gram_chunk(
+        gram_mlx = gram_mlx,
+        xy_mlx = xy_mlx,
+        beta_mlx = beta_mlx,
+        z_mlx = z_mlx,
+        t_prev = t_prev,
+        step = step,
+        thresh = thresh,
+        ridge_penalty = ridge_penalty,
+        n_steps = n_steps
+      )
+
+      beta_mlx <- state$beta
+      z_mlx <- state$z
+      t_prev <- state$t_prev
+      remaining <- remaining - n_steps
+
+      if (as.logical(state$delta_max < tol)) {
+        break
+      }
+    }
+
+    beta_store_mlx <- Rmlx::mlx_slice_update(
+      beta_store_mlx,
+      beta_mlx,
+      start = c(1L, idx),
+      stop = c(n_pred, idx)
+    )
+    intercept_store_mlx <- Rmlx::mlx_slice_update(
+      intercept_store_mlx,
+      intercept_mlx,
       start = c(idx, 1L),
       stop = c(idx, 1L)
     )
@@ -357,6 +500,14 @@ mlxs_glmnet <- function(x,
     exp(seq(log(lambda_max), log(lambda_min), length.out = nlambda))
   } else {
     sort(as.numeric(lambda), decreasing = TRUE)
+  }
+}
+
+.mlxs_glmnet_choose_gaussian_solver <- function(n_obs, n_pred, n_lambda) {
+  if (n_lambda >= 10L && n_pred <= 1024L && n_obs >= 50L * n_pred) {
+    "gram"
+  } else {
+    "dense"
   }
 }
 

--- a/R/mlxs-glmnet.R
+++ b/R/mlxs-glmnet.R
@@ -4,9 +4,9 @@
 #' the heavy linear algebra. Currently supports Gaussian and binomial families
 #' with an optional intercept and column standardisation.
 #'
-#' @note This function is early work. It is currently only faster than
-#'   [glmnet::glmnet()] for very large data: roughly 100,000 observations
-#'   and 1000 predictors.
+#' @note This function is a proof-of-concept. On large dense problems it is
+#'   typically several times slower than the highly optimised
+#'   [glmnet::glmnet()] implementation.
 #'
 #' @param x Numeric matrix of predictors (observations in rows).
 #' @param y Numeric response vector (for binomial, values must be 0/1).
@@ -25,42 +25,31 @@
 #' @param maxit Maximum proximal-gradient iterations per lambda value.
 #' @param tol Convergence tolerance on the coefficient updates.
 #' @param use_strong_rules Should strong rules be used to screen out inactive
-#'   predictors? This can speed up fitting for sparse problems.
+#'   predictors? (Ignored in this legacy implementation; kept for compatibility.)
 #' @param block_size Number of coefficients to update per gradient evaluation.
-#'   Set to 1 for classic coordinate descent; larger values (e.g., 16-64) batch
-#'   updates for speed at the cost of a slightly more conservative step size.
-#' @return An object of class `mlxs_glmnet` containing MLX arrays for the
-#'   coefficient path (`beta`), intercepts (`a0`), and lambda sequence
-#'   (`lambda`). Use `as.matrix()` / `as.numeric()` or the provided print
-#'   method to materialise these on the host when needed.
+#'   Included for interface compatibility; not used by this implementation.
+#' @return An object of class `mlxs_glmnet` containing the fitted coefficient
+#'   path, intercepts, lambda sequence, and scaling information.
 #' @export
-mlxs_glmnet <- function(
-  x,
-  y,
-  family = mlxs_gaussian(),
-  alpha = 1,
-  lambda = NULL,
-  nlambda = 100,
-  lambda_min_ratio = 1e-4,
-  standardize = TRUE,
-  intercept = TRUE,
-  maxit = 1000,
-  tol = 1e-6,
-  use_strong_rules = TRUE,
-  block_size = 16L
-) {
+mlxs_glmnet <- function(x,
+                        y,
+                        family = mlxs_gaussian(),
+                        alpha = 1,
+                        lambda = NULL,
+                        nlambda = 100,
+                        lambda_min_ratio = 1e-4,
+                        standardize = TRUE,
+                        intercept = TRUE,
+                        maxit = 1000,
+                        tol = 1e-6,
+                        use_strong_rules = TRUE,
+                        block_size = 16L) {
   family_name <- family$family
   if (!family_name %in% c("gaussian", "binomial", "quasibinomial")) {
-    stop(
-      "mlxs_glmnet() currently supports gaussian and binomial families.",
-      call. = FALSE
-    )
+    stop("mlxs_glmnet() currently supports gaussian and binomial families.", call. = FALSE)
   }
   if (alpha <= 0) {
-    stop(
-      "alpha must be > 0 for the current MLX elastic-net implementation.",
-      call. = FALSE
-    )
+    stop("alpha must be > 0 for the current MLX elastic-net implementation.", call. = FALSE)
   }
 
   x <- as.matrix(x)
@@ -78,10 +67,7 @@ mlxs_glmnet <- function(
 
   if (standardize) {
     x_std_mlx <- scale(x_mlx)
-    x_center <- Rmlx::mlx_reshape(
-      attr(x_std_mlx, "scaled:center"),
-      c(n_pred, 1)
-    )
+    x_center <- Rmlx::mlx_reshape(attr(x_std_mlx, "scaled:center"), c(n_pred, 1))
     x_scale <- Rmlx::mlx_reshape(attr(x_std_mlx, "scaled:scale"), c(n_pred, 1))
   } else {
     x_std_mlx <- x_mlx
@@ -105,8 +91,8 @@ mlxs_glmnet <- function(
   mu0_mlx <- Rmlx::as_mlx(matrix(mu0, ncol = 1))
   residual0_mlx <- mu0_mlx - y_mlx
   z0_mlx <- crossprod(x_std_mlx, residual0_mlx) / n_obs
-  z0_vals <- as.numeric(z0_mlx)
-  lambda_max <- max(abs(z0_vals)) / max(alpha, 1e-8)
+  z0 <- as.numeric(z0_mlx)
+  lambda_max <- max(abs(z0)) / max(alpha, 1e-8)
   if (is.finite(lambda_max) && lambda_max == 0) {
     lambda_max <- 1
   }
@@ -126,309 +112,118 @@ mlxs_glmnet <- function(
   # Keep stores as MLX to avoid per-lambda conversions
   beta_store_mlx <- Rmlx::mlx_zeros(c(n_pred, n_lambda))
   intercept_store_mlx <- Rmlx::mlx_zeros(c(n_lambda, 1))
-  grad_prev <- z0_mlx
+  grad_prev_mlx <- z0_mlx
   lambda_prev <- lambda[1]
 
   col_sq_sums_mlx <- Rmlx::colSums(x_std_mlx^2)
   col_sq_sums <- as.numeric(col_sq_sums_mlx)
+  base_lipschitz <- max(col_sq_sums) / n_obs
+  if (family_name %in% c("binomial", "quasibinomial")) {
+    base_lipschitz <- 0.25 * base_lipschitz
+  }
+
+  # Tolerance as MLX scalar for comparisons
+  tol_mlx <- Rmlx::as_mlx(matrix(tol, nrow = 1, ncol = 1))
+
+  # Get compiled iteration function (caches on first call)
+  iter_func <- .get_compiled_iteration()
+
+  # Family flag for compiled function (1 = gaussian, 0 = binomial)
+  is_gaussian_flag <- Rmlx::as_mlx(matrix(
+    if (family_name == "gaussian") 1 else 0,
+    nrow = 1, ncol = 1
+  ))
 
   eta_mlx <- x_std_mlx %*% beta_mlx + ones_mlx * intercept_mlx
   mu_mlx <- family$linkinv(eta_mlx)
   residual_mlx <- mu_mlx - y_mlx
 
-  # Coordinate descent path
   for (idx in seq_along(lambda)) {
     lambda_val <- lambda[idx]
-
-    # Run coordinate descent for this lambda
-    ridge_penalty <- lambda_val * (1 - alpha)
-    l1_penalty <- lambda_val * alpha
-
-    # Apply strong rules screening
-    active_set <- rep(TRUE, n_pred)
-    if (use_strong_rules && idx > 1) {
-      grad_prev_host <- as.numeric(grad_prev)
-      # Strong rule: discard j if |grad_j(lambda_prev)| < alpha * (2*lambda_k - lambda_{k-1})
-      strong_threshold <- alpha * (2 * lambda_val - lambda_prev)
-      active_set <- abs(grad_prev_host) >= strong_threshold
-
-      # Handle NAs (treat as active to be safe)
-      active_set[is.na(active_set)] <- TRUE
-
-      # Always keep variables that were active at previous lambda
-      beta_prev_active <- abs(as.numeric(beta_mlx)) > 0
-      active_set <- active_set | beta_prev_active
-
-      # Ensure at least one predictor is active
-      if (!any(active_set, na.rm = TRUE)) {
-        active_set[which.max(abs(grad_prev_host))] <- TRUE
-      }
+    step <- 1 / (base_lipschitz + lambda_val * (1 - alpha))
+    if (!is.finite(step) || step <= 0) {
+      step <- 1e-3
     }
-    active_mask <- Rmlx::as_mlx(
-      matrix(as.integer(active_set), ncol = 1),
-      dtype = "bool"
-    )
 
-    # Fit with KKT checking loop
-    repeat {
-      active_set <- as.logical(active_mask)
-      # Subset to active predictors (if all active, this is the full set)
-      active_idx <- which(active_set)
-
-      # Debug: check for empty active set
+    if (idx == 1) {
+      active_idx <- seq_len(n_pred)
+    } else {
+      cutoff <- alpha * (2 * lambda_val - lambda_prev)
+      grad_prev_host <- as.numeric(grad_prev_mlx)
+      strong_set <- which(abs(grad_prev_host) > cutoff)
+      # Convert previous beta column to R only for strong rules check
+      beta_numeric <- as.numeric(beta_store_mlx[, idx - 1])
+      nonzero_set <- which(beta_numeric != 0)
+      active_idx <- sort(unique(c(strong_set, nonzero_set)))
       if (length(active_idx) == 0) {
-        stop(
-          "Empty active set at lambda index ",
-          idx,
-          ". This should not happen - strong rules logic has a bug."
-        )
+        active_idx <- which.max(abs(grad_prev_host))
       }
-
-      x_active_mlx <- x_std_mlx[, active_idx, drop = FALSE]
-      beta_active_mlx <- beta_mlx[active_idx, , drop = FALSE]
-      col_sq_sums_active <- col_sq_sums[active_idx]
-
-      # Define loss and gradient on active set
-      if (family_name == "gaussian") {
-        loss_active <- function(beta) {
-          eta <- x_active_mlx %*% beta + ones_mlx * intercept_mlx
-          loss_smooth <- Rmlx::mlx_mse_loss(eta, y_mlx, reduction = "mean")
-          loss_smooth <- loss_smooth + 0.5 * ridge_penalty * sum(beta^2)
-          loss_smooth
-        }
-        grad_active <- function(beta) {
-          eta <- x_active_mlx %*% beta + ones_mlx * intercept_mlx
-          residual <- y_mlx - eta
-          grad <- -crossprod(x_active_mlx, residual) / n_obs
-          grad <- grad + ridge_penalty * beta
-          grad
-        }
-      } else {
-        loss_active <- function(beta) {
-          eta <- x_active_mlx %*% beta + ones_mlx * intercept_mlx
-          mu <- 1 / (1 + exp(-eta))
-          loss_smooth <- Rmlx::mlx_binary_cross_entropy(
-            mu,
-            y_mlx,
-            reduction = "mean"
-          )
-          loss_smooth <- loss_smooth + 0.5 * ridge_penalty * sum(beta^2)
-          loss_smooth
-        }
-        grad_active <- function(beta) {
-          eta <- x_active_mlx %*% beta + ones_mlx * intercept_mlx
-          mu <- 1 / (1 + exp(-eta))
-          residual <- mu - y_mlx
-          grad <- crossprod(x_active_mlx, residual) / n_obs
-          grad <- grad + ridge_penalty * beta
-          grad
-        }
-      }
-
-      lipschitz_active <- col_sq_sums_active / n_obs + ridge_penalty
-      if (family_name %in% c("binomial", "quasibinomial")) {
-        lipschitz_active <- 0.25 * lipschitz_active
-      }
-
-      # Add small epsilon for numerical stability when ridge_penalty is 0
-      lipschitz_active <- lipschitz_active + 1e-8
-
-      lipschitz_active <- Rmlx::mlx_reshape(
-        Rmlx::as_mlx(lipschitz_active),
-        c(length(active_idx), 1)
-      )
-
-      block_size_active <- max(
-        1L,
-        min(as.integer(block_size), length(active_idx))
-      )
-      if (block_size_active > 1L && family_name == "gaussian") {
-        block_indices <- split(
-          seq_len(length(active_idx)),
-          ceiling(seq_len(length(active_idx)) / block_size_active)
-        )
-        for (blk in block_indices) {
-          if (length(blk) <= 1L) {
-            next
-          }
-          x_block <- x_active_mlx[, blk, drop = FALSE]
-          gram <- crossprod(x_block, x_block) / n_obs
-          if (ridge_penalty > 0) {
-            eye_blk <- Rmlx::mlx_eye(
-              length(blk),
-              dtype = gram$dtype,
-              device = gram$device
-            )
-            gram <- gram + ridge_penalty * eye_blk
-          }
-          svd_vals <- Rmlx::svd(gram, nu = 0, nv = 0)
-          spectral <- max(as.numeric(svd_vals$d))
-          diag_vals <- as.numeric(lipschitz_active[blk, , drop = FALSE])
-          diag_max <- max(diag_vals)
-          if (spectral > diag_max && diag_max > 0) {
-            scale <- spectral / diag_max
-            lipschitz_active[blk, ] <- lipschitz_active[blk, ] * scale
-          }
-        }
-      } else {
-        block_size_active <- 1L
-      }
-
-      grad_cache <- NULL
-      if (family_name == "gaussian") {
-        grad_cache <- new.env(parent = emptyenv())
-        grad_cache$type <- "gaussian"
-        grad_cache$x <- x_active_mlx
-        grad_cache$n_obs <- n_obs
-        grad_cache$ridge_penalty <- ridge_penalty
-        grad_cache$residual <- y_mlx -
-          (x_active_mlx %*% beta_active_mlx + ones_mlx * intercept_mlx)
-      } else if (family_name %in% c("binomial", "quasibinomial")) {
-        grad_cache <- new.env(parent = emptyenv())
-        grad_cache$type <- "binomial"
-        grad_cache$x <- x_active_mlx
-        grad_cache$n_obs <- n_obs
-        grad_cache$ridge_penalty <- ridge_penalty
-        grad_cache$y <- y_mlx
-        grad_cache$eta <- x_active_mlx %*%
-          beta_active_mlx +
-          ones_mlx * intercept_mlx
-        grad_cache$mu <- 1 / (1 + exp(-grad_cache$eta))
-        grad_cache$residual <- grad_cache$mu - y_mlx
-      }
-
-      # Run coordinate descent (let it handle compilation internally)
-
-      result <- Rmlx::mlx_coordinate_descent(
-        loss_fn = loss_active,
-        beta_init = beta_active_mlx,
-        lambda = l1_penalty,
-        grad_fn = grad_active,
-        lipschitz = lipschitz_active,
-        max_iter = maxit,
-        tol = tol,
-        block_size = block_size_active,
-        grad_cache = grad_cache
-      )
-
-      # Check for NaN in result
-      result_beta_vec <- as.numeric(result$beta)
-      if (any(is.nan(result_beta_vec))) {
-        warning(sprintf(
-          "Coordinate descent produced NaN at lambda index %d (lambda=%.6f, converged=%s, iterations=%d)",
-          idx,
-          lambda_val,
-          result$converged,
-          result$iterations
-        ))
-      }
-
-      # Expand beta back to full size (if all active, this is a no-op)
-      beta_mlx <- Rmlx::mlx_zeros(c(n_pred, 1))
-      beta_mlx[active_idx, ] <- result$beta
-
-      # Update intercept
-      if (intercept) {
-        if (family_name == "gaussian") {
-          residual_mlx <- y_mlx - x_std_mlx %*% beta_mlx
-          intercept_mlx <- sum(residual_mlx) / n_obs
-        } else if (family_name %in% c("binomial", "quasibinomial")) {
-          for (intercept_iter in seq_len(2)) {
-            eta <- x_std_mlx %*% beta_mlx + ones_mlx * intercept_mlx
-            mu <- 1 / (1 + exp(-eta))
-            residual <- mu - y_mlx
-            w <- mu * (1 - mu)
-            grad_intercept <- sum(residual) / n_obs
-            hess_intercept <- sum(w) / n_obs
-            intercept_new <- intercept_mlx -
-              grad_intercept / (hess_intercept + 1e-8)
-            if (as.logical(abs(intercept_new - intercept_mlx) < tol)) {
-              intercept_mlx <- intercept_new
-              break
-            }
-            intercept_mlx <- intercept_new
-          }
-        }
-      } else {
-        intercept_mlx <- Rmlx::as_mlx(0)
-      }
-
-      # Check KKT conditions if strong rules were used and some predictors were screened out
-      if (!use_strong_rules || sum(active_set) == n_pred) {
-        break # No screening, so no KKT check needed
-      }
-
-      # Compute gradient for all predictors
-      eta_mlx <- x_std_mlx %*% beta_mlx + ones_mlx * intercept_mlx
-      if (family_name == "gaussian") {
-        residual_full <- y_mlx - eta_mlx
-        grad_full <- -crossprod(x_std_mlx, residual_full) / n_obs
-      } else {
-        mu <- 1 / (1 + exp(-eta_mlx))
-        residual_full <- mu - y_mlx
-        grad_full <- crossprod(x_std_mlx, residual_full) / n_obs
-      }
-      grad_full <- grad_full + ridge_penalty * beta_mlx
-
-      # Check KKT violations for inactive predictors
-      inactive_mask <- !active_mask
-      kkt_threshold <- l1_penalty + tol
-      violations_mask <- inactive_mask & (abs(grad_full) > kkt_threshold)
-      violations <- as.logical(violations_mask)
-
-      # Handle NAs (treat as no violation to be safe)
-      violations[is.na(violations)] <- FALSE
-
-      if (!any(violations, na.rm = TRUE)) {
-        break # No violations, we're done
-      }
-
-      # Add violators to active set and refit
-      active_set <- active_set | violations
-      active_mask <- active_mask | violations_mask
     }
 
-    # Store results
+    # Precompute threshold for compiled function
+    thresh <- lambda_val * alpha * step
+    # Subset once per lambda (active set fixed inside strong-rule loop)
+    x_active <- x_std_mlx[, active_idx, drop = FALSE]
+
+    for (iter in seq_len(maxit)) {
+      beta_prev_subset <- beta_mlx[active_idx, , drop = FALSE]
+
+      # Call compiled iteration function
+      result <- iter_func(
+        x_active, beta_prev_subset, residual_mlx,
+        intercept_mlx, eta_mlx, y_mlx, ones_mlx,
+        n_obs, step, lambda_val, alpha, thresh,
+        is_gaussian_flag
+      )
+
+      # Extract results
+      beta_mlx[active_idx, ] <- result$beta_new
+      intercept_mlx <- result$intercept_new
+      eta_mlx <- result$eta_new
+      residual_mlx <- result$residual_new
+
+      # Convergence check using MLX operations
+      if (iter %% 10 == 0 || iter == maxit) {
+        # Batch convergence checks to cut reduction/transfer overhead
+        delta_beta_max <- as.numeric(max(abs(result$delta_beta)))
+        intercept_delta_abs <- as.numeric(abs(result$intercept_delta))
+        if (delta_beta_max < tol && intercept_delta_abs < tol) break
+      }
+    }
+
+    # Store in MLX - no conversion until the end
     beta_store_mlx[, idx] <- beta_mlx
     intercept_store_mlx[idx, ] <- intercept_mlx
 
-    # Force evaluation at each lambda (outer loop iteration)
-    # See: https://ml-explore.github.io/mlx/build/html/usage/lazy_evaluation.html
-    Rmlx::mlx_eval(beta_mlx)
-    Rmlx::mlx_eval(intercept_mlx)
-
-    # Update for strong rules (future optimization)
-    eta_mlx <- x_std_mlx %*% beta_mlx + ones_mlx * intercept_mlx
-    residual_mlx <- y_mlx - eta_mlx
-    grad_prev <- crossprod(x_std_mlx, residual_mlx) / n_obs
+    grad_prev_mlx <- crossprod(x_std_mlx, residual_mlx) / n_obs
     lambda_prev <- lambda_val
   }
 
   if (standardize) {
     beta_unscaled <- beta_store_mlx / x_scale
     intercept_adjustment <- Rmlx::colSums(beta_unscaled * x_center)
-    intercept_adjustment <- Rmlx::mlx_reshape(
-      intercept_adjustment,
-      c(n_lambda, 1)
-    )
+    intercept_adjustment <- Rmlx::mlx_reshape(intercept_adjustment, c(n_lambda, 1))
     intercept_unscaled <- intercept_store_mlx - intercept_adjustment
   } else {
     beta_unscaled <- beta_store_mlx
     intercept_unscaled <- intercept_store_mlx
   }
+  
+  # Convert to R only once at the very end
+  beta_unscaled <- as.matrix(beta_unscaled)
+  intercept_unscaled <- as.numeric(intercept_unscaled)
 
+  rownames(beta_unscaled) <- colnames(x)
   result <- list(
     a0 = intercept_unscaled,
     beta = beta_unscaled,
-    lambda = Rmlx::as_mlx(lambda),
-    lambda_numeric = lambda,
+    lambda = lambda,
     alpha = alpha,
     family = family_name,
     standardize = standardize,
     intercept = intercept,
     x_center = x_center,
     x_scale = x_scale,
-    coef_names = colnames(x),
     call = match.call()
   )
 

--- a/R/mlxs-glmnet.R
+++ b/R/mlxs-glmnet.R
@@ -2,7 +2,8 @@
 #'
 #' Fit lasso or elastic-net penalised regression paths using MLX arrays for the
 #' heavy linear algebra. Dense Gaussian and binomial paths stay on the MLX
-#' backend throughout the iterative updates.
+#' backend throughout the iterative updates, with repeated chunk updates traced
+#' through [Rmlx::mlx_compile()] to reduce host overhead.
 #'
 #' @note This implementation uses dense MLX updates rather than `glmnet`'s
 #'   coordinate-descent Fortran kernels, so `glmnet::glmnet()` can still be
@@ -241,27 +242,32 @@ mlxs_glmnet <- function(x,
 
   col_sq_sums <- as.numeric(Rmlx::colSums(x_mlx^2))
   base_lipschitz <- max(col_sq_sums) / n_obs
+  n_obs_mlx <- Rmlx::as_mlx(n_obs)
+  zero_mlx <- Rmlx::as_mlx(0)
 
   for (idx in seq_along(lambda)) {
     lambda_val <- lambda[idx]
     step <- 1 / (base_lipschitz + lambda_val * (1 - alpha))
     thresh <- lambda_val * alpha * step
     ridge_penalty <- lambda_val * (1 - alpha)
+    step_mlx <- Rmlx::as_mlx(step)
+    thresh_mlx <- Rmlx::as_mlx(thresh)
+    ridge_penalty_mlx <- Rmlx::as_mlx(ridge_penalty)
 
     remaining <- maxit
     while (remaining > 0L) {
       n_steps <- min(chunk_size, remaining)
-      state <- .mlxs_glmnet_gaussian_chunk(
-        x_mlx = x_mlx,
-        beta_mlx = beta_mlx,
-        eta_mlx = eta_mlx,
-        residual_mlx = residual_mlx,
-        y_mlx = y_mlx,
-        n_obs = n_obs,
-        step = step,
-        thresh = thresh,
-        ridge_penalty = ridge_penalty,
-        n_steps = n_steps
+      state <- .mlxs_glmnet_get_compiled_chunk("gaussian", n_steps)(
+        x_mlx,
+        beta_mlx,
+        eta_mlx,
+        residual_mlx,
+        y_mlx,
+        n_obs_mlx,
+        step_mlx,
+        thresh_mlx,
+        ridge_penalty_mlx,
+        zero_mlx
       )
 
       beta_mlx <- state$beta
@@ -329,34 +335,42 @@ mlxs_glmnet <- function(x,
   intercept_mlx <- Rmlx::mlx_matrix(y_mean, nrow = 1L, ncol = 1L)
   gram_lipschitz <- as.numeric(max(Rmlx::colSums(abs(gram_mlx))))
   effective_maxit <- min(maxit, 200L)
+  zero_mlx <- Rmlx::as_mlx(0)
+  one_mlx <- Rmlx::as_mlx(1)
+  four_mlx <- Rmlx::as_mlx(4)
 
   for (idx in seq_along(lambda)) {
     lambda_val <- lambda[idx]
     ridge_penalty <- lambda_val * (1 - alpha)
     step <- 1 / (gram_lipschitz + ridge_penalty)
     thresh <- lambda_val * alpha * step
+    step_mlx <- Rmlx::as_mlx(step)
+    thresh_mlx <- Rmlx::as_mlx(thresh)
+    ridge_penalty_mlx <- Rmlx::as_mlx(ridge_penalty)
 
     remaining <- effective_maxit
     z_mlx <- beta_mlx
-    t_prev <- 1
+    t_prev_mlx <- one_mlx
 
     while (remaining > 0L) {
       n_steps <- min(chunk_size, remaining)
-      state <- .mlxs_glmnet_gaussian_gram_chunk(
-        gram_mlx = gram_mlx,
-        xy_mlx = xy_mlx,
-        beta_mlx = beta_mlx,
-        z_mlx = z_mlx,
-        t_prev = t_prev,
-        step = step,
-        thresh = thresh,
-        ridge_penalty = ridge_penalty,
-        n_steps = n_steps
+      state <- .mlxs_glmnet_get_compiled_chunk("gaussian_gram", n_steps)(
+        gram_mlx,
+        xy_mlx,
+        beta_mlx,
+        z_mlx,
+        t_prev_mlx,
+        step_mlx,
+        thresh_mlx,
+        ridge_penalty_mlx,
+        zero_mlx,
+        one_mlx,
+        four_mlx
       )
 
       beta_mlx <- state$beta
       z_mlx <- state$z
-      t_prev <- state$t_prev
+      t_prev_mlx <- state$t_prev
       remaining <- remaining - n_steps
 
       if (as.logical(state$delta_max < tol)) {
@@ -423,30 +437,38 @@ mlxs_glmnet <- function(x,
   intercept_store_mlx <- Rmlx::mlx_zeros(c(n_lambda, 1L))
   col_sq_sums <- as.numeric(Rmlx::colSums(x_mlx^2))
   base_lipschitz <- 0.25 * max(col_sq_sums) / n_obs
+  n_obs_mlx <- Rmlx::as_mlx(n_obs)
+  zero_mlx <- Rmlx::as_mlx(0)
 
   for (idx in seq_along(lambda)) {
     lambda_val <- lambda[idx]
     step <- 1 / (base_lipschitz + lambda_val * (1 - alpha))
     thresh <- lambda_val * alpha * step
     ridge_penalty <- lambda_val * (1 - alpha)
+    step_mlx <- Rmlx::as_mlx(step)
+    thresh_mlx <- Rmlx::as_mlx(thresh)
+    ridge_penalty_mlx <- Rmlx::as_mlx(ridge_penalty)
 
     remaining <- maxit
     while (remaining > 0L) {
       n_steps <- min(chunk_size, remaining)
-      state <- .mlxs_glmnet_binomial_chunk(
-        x_mlx = x_mlx,
-        beta_mlx = beta_mlx,
-        intercept_mlx = intercept_mlx,
-        eta_mlx = eta_mlx,
-        residual_mlx = residual_mlx,
-        y_mlx = y_mlx,
-        ones_mlx = ones_mlx,
-        n_obs = n_obs,
-        step = step,
-        thresh = thresh,
-        ridge_penalty = ridge_penalty,
-        n_steps = n_steps,
+      state <- .mlxs_glmnet_get_compiled_chunk(
+        "binomial",
+        n_steps,
         fit_intercept = intercept
+      )(
+        x_mlx,
+        beta_mlx,
+        intercept_mlx,
+        eta_mlx,
+        residual_mlx,
+        y_mlx,
+        ones_mlx,
+        n_obs_mlx,
+        step_mlx,
+        thresh_mlx,
+        ridge_penalty_mlx,
+        zero_mlx
       )
 
       beta_mlx <- state$beta

--- a/R/mlxs-glmnet.R
+++ b/R/mlxs-glmnet.R
@@ -4,9 +4,9 @@
 #' the heavy linear algebra. Currently supports Gaussian and binomial families
 #' with an optional intercept and column standardisation.
 #'
-#' @note This function is a proof-of-concept. On large dense problems it is
-#'   typically several times slower than the highly optimised
-#'   [glmnet::glmnet()] implementation.
+#' @note This function is early work. It is currently only faster than
+#'   [glmnet::glmnet()] for very large data: roughly 100,000 observations
+#'   and 1000 predictors.
 #'
 #' @param x Numeric matrix of predictors (observations in rows).
 #' @param y Numeric response vector (for binomial, values must be 0/1).
@@ -25,31 +25,42 @@
 #' @param maxit Maximum proximal-gradient iterations per lambda value.
 #' @param tol Convergence tolerance on the coefficient updates.
 #' @param use_strong_rules Should strong rules be used to screen out inactive
-#'   predictors? (Ignored in this legacy implementation; kept for compatibility.)
+#'   predictors? This can speed up fitting for sparse problems.
 #' @param block_size Number of coefficients to update per gradient evaluation.
-#'   Included for interface compatibility; not used by this implementation.
-#' @return An object of class `mlxs_glmnet` containing the fitted coefficient
-#'   path, intercepts, lambda sequence, and scaling information.
+#'   Set to 1 for classic coordinate descent; larger values (e.g., 16-64) batch
+#'   updates for speed at the cost of a slightly more conservative step size.
+#' @return An object of class `mlxs_glmnet` containing MLX arrays for the
+#'   coefficient path (`beta`), intercepts (`a0`), and lambda sequence
+#'   (`lambda`). Use `as.matrix()` / `as.numeric()` or the provided print
+#'   method to materialise these on the host when needed.
 #' @export
-mlxs_glmnet <- function(x,
-                        y,
-                        family = mlxs_gaussian(),
-                        alpha = 1,
-                        lambda = NULL,
-                        nlambda = 100,
-                        lambda_min_ratio = 1e-4,
-                        standardize = TRUE,
-                        intercept = TRUE,
-                        maxit = 1000,
-                        tol = 1e-6,
-                        use_strong_rules = TRUE,
-                        block_size = 16L) {
+mlxs_glmnet <- function(
+  x,
+  y,
+  family = mlxs_gaussian(),
+  alpha = 1,
+  lambda = NULL,
+  nlambda = 100,
+  lambda_min_ratio = 1e-4,
+  standardize = TRUE,
+  intercept = TRUE,
+  maxit = 1000,
+  tol = 1e-6,
+  use_strong_rules = TRUE,
+  block_size = 16L
+) {
   family_name <- family$family
   if (!family_name %in% c("gaussian", "binomial", "quasibinomial")) {
-    stop("mlxs_glmnet() currently supports gaussian and binomial families.", call. = FALSE)
+    stop(
+      "mlxs_glmnet() currently supports gaussian and binomial families.",
+      call. = FALSE
+    )
   }
   if (alpha <= 0) {
-    stop("alpha must be > 0 for the current MLX elastic-net implementation.", call. = FALSE)
+    stop(
+      "alpha must be > 0 for the current MLX elastic-net implementation.",
+      call. = FALSE
+    )
   }
 
   x <- as.matrix(x)
@@ -67,7 +78,10 @@ mlxs_glmnet <- function(x,
 
   if (standardize) {
     x_std_mlx <- scale(x_mlx)
-    x_center <- Rmlx::mlx_reshape(attr(x_std_mlx, "scaled:center"), c(n_pred, 1))
+    x_center <- Rmlx::mlx_reshape(
+      attr(x_std_mlx, "scaled:center"),
+      c(n_pred, 1)
+    )
     x_scale <- Rmlx::mlx_reshape(attr(x_std_mlx, "scaled:scale"), c(n_pred, 1))
   } else {
     x_std_mlx <- x_mlx
@@ -91,8 +105,8 @@ mlxs_glmnet <- function(x,
   mu0_mlx <- Rmlx::as_mlx(matrix(mu0, ncol = 1))
   residual0_mlx <- mu0_mlx - y_mlx
   z0_mlx <- crossprod(x_std_mlx, residual0_mlx) / n_obs
-  z0 <- as.numeric(z0_mlx)
-  lambda_max <- max(abs(z0)) / max(alpha, 1e-8)
+  z0_vals <- as.numeric(z0_mlx)
+  lambda_max <- max(abs(z0_vals)) / max(alpha, 1e-8)
   if (is.finite(lambda_max) && lambda_max == 0) {
     lambda_max <- 1
   }
@@ -112,118 +126,309 @@ mlxs_glmnet <- function(x,
   # Keep stores as MLX to avoid per-lambda conversions
   beta_store_mlx <- Rmlx::mlx_zeros(c(n_pred, n_lambda))
   intercept_store_mlx <- Rmlx::mlx_zeros(c(n_lambda, 1))
-  grad_prev_mlx <- z0_mlx
+  grad_prev <- z0_mlx
   lambda_prev <- lambda[1]
 
   col_sq_sums_mlx <- Rmlx::colSums(x_std_mlx^2)
   col_sq_sums <- as.numeric(col_sq_sums_mlx)
-  base_lipschitz <- max(col_sq_sums) / n_obs
-  if (family_name %in% c("binomial", "quasibinomial")) {
-    base_lipschitz <- 0.25 * base_lipschitz
-  }
-
-  # Tolerance as MLX scalar for comparisons
-  tol_mlx <- Rmlx::as_mlx(matrix(tol, nrow = 1, ncol = 1))
-
-  # Get compiled iteration function (caches on first call)
-  iter_func <- .get_compiled_iteration()
-
-  # Family flag for compiled function (1 = gaussian, 0 = binomial)
-  is_gaussian_flag <- Rmlx::as_mlx(matrix(
-    if (family_name == "gaussian") 1 else 0,
-    nrow = 1, ncol = 1
-  ))
 
   eta_mlx <- x_std_mlx %*% beta_mlx + ones_mlx * intercept_mlx
   mu_mlx <- family$linkinv(eta_mlx)
   residual_mlx <- mu_mlx - y_mlx
 
+  # Coordinate descent path
   for (idx in seq_along(lambda)) {
     lambda_val <- lambda[idx]
-    step <- 1 / (base_lipschitz + lambda_val * (1 - alpha))
-    if (!is.finite(step) || step <= 0) {
-      step <- 1e-3
-    }
 
-    if (idx == 1) {
-      active_idx <- seq_len(n_pred)
-    } else {
-      cutoff <- alpha * (2 * lambda_val - lambda_prev)
-      grad_prev_host <- as.numeric(grad_prev_mlx)
-      strong_set <- which(abs(grad_prev_host) > cutoff)
-      # Convert previous beta column to R only for strong rules check
-      beta_numeric <- as.numeric(beta_store_mlx[, idx - 1])
-      nonzero_set <- which(beta_numeric != 0)
-      active_idx <- sort(unique(c(strong_set, nonzero_set)))
-      if (length(active_idx) == 0) {
-        active_idx <- which.max(abs(grad_prev_host))
+    # Run coordinate descent for this lambda
+    ridge_penalty <- lambda_val * (1 - alpha)
+    l1_penalty <- lambda_val * alpha
+
+    # Apply strong rules screening
+    active_set <- rep(TRUE, n_pred)
+    if (use_strong_rules && idx > 1) {
+      grad_prev_host <- as.numeric(grad_prev)
+      # Strong rule: discard j if |grad_j(lambda_prev)| < alpha * (2*lambda_k - lambda_{k-1})
+      strong_threshold <- alpha * (2 * lambda_val - lambda_prev)
+      active_set <- abs(grad_prev_host) >= strong_threshold
+
+      # Handle NAs (treat as active to be safe)
+      active_set[is.na(active_set)] <- TRUE
+
+      # Always keep variables that were active at previous lambda
+      beta_prev_active <- abs(as.numeric(beta_mlx)) > 0
+      active_set <- active_set | beta_prev_active
+
+      # Ensure at least one predictor is active
+      if (!any(active_set, na.rm = TRUE)) {
+        active_set[which.max(abs(grad_prev_host))] <- TRUE
       }
     }
+    active_mask <- Rmlx::as_mlx(
+      matrix(as.integer(active_set), ncol = 1),
+      dtype = "bool"
+    )
 
-    # Precompute threshold for compiled function
-    thresh <- lambda_val * alpha * step
-    # Subset once per lambda (active set fixed inside strong-rule loop)
-    x_active <- x_std_mlx[, active_idx, drop = FALSE]
+    # Fit with KKT checking loop
+    repeat {
+      active_set <- as.logical(active_mask)
+      # Subset to active predictors (if all active, this is the full set)
+      active_idx <- which(active_set)
 
-    for (iter in seq_len(maxit)) {
-      beta_prev_subset <- beta_mlx[active_idx, , drop = FALSE]
+      # Debug: check for empty active set
+      if (length(active_idx) == 0) {
+        stop(
+          "Empty active set at lambda index ",
+          idx,
+          ". This should not happen - strong rules logic has a bug."
+        )
+      }
 
-      # Call compiled iteration function
-      result <- iter_func(
-        x_active, beta_prev_subset, residual_mlx,
-        intercept_mlx, eta_mlx, y_mlx, ones_mlx,
-        n_obs, step, lambda_val, alpha, thresh,
-        is_gaussian_flag
+      x_active_mlx <- x_std_mlx[, active_idx, drop = FALSE]
+      beta_active_mlx <- beta_mlx[active_idx, , drop = FALSE]
+      col_sq_sums_active <- col_sq_sums[active_idx]
+
+      # Define loss and gradient on active set
+      if (family_name == "gaussian") {
+        loss_active <- function(beta) {
+          eta <- x_active_mlx %*% beta + ones_mlx * intercept_mlx
+          loss_smooth <- Rmlx::mlx_mse_loss(eta, y_mlx, reduction = "mean")
+          loss_smooth <- loss_smooth + 0.5 * ridge_penalty * sum(beta^2)
+          loss_smooth
+        }
+        grad_active <- function(beta) {
+          eta <- x_active_mlx %*% beta + ones_mlx * intercept_mlx
+          residual <- y_mlx - eta
+          grad <- -crossprod(x_active_mlx, residual) / n_obs
+          grad <- grad + ridge_penalty * beta
+          grad
+        }
+      } else {
+        loss_active <- function(beta) {
+          eta <- x_active_mlx %*% beta + ones_mlx * intercept_mlx
+          mu <- 1 / (1 + exp(-eta))
+          loss_smooth <- Rmlx::mlx_binary_cross_entropy(
+            mu,
+            y_mlx,
+            reduction = "mean"
+          )
+          loss_smooth <- loss_smooth + 0.5 * ridge_penalty * sum(beta^2)
+          loss_smooth
+        }
+        grad_active <- function(beta) {
+          eta <- x_active_mlx %*% beta + ones_mlx * intercept_mlx
+          mu <- 1 / (1 + exp(-eta))
+          residual <- mu - y_mlx
+          grad <- crossprod(x_active_mlx, residual) / n_obs
+          grad <- grad + ridge_penalty * beta
+          grad
+        }
+      }
+
+      lipschitz_active <- col_sq_sums_active / n_obs + ridge_penalty
+      if (family_name %in% c("binomial", "quasibinomial")) {
+        lipschitz_active <- 0.25 * lipschitz_active
+      }
+
+      # Add small epsilon for numerical stability when ridge_penalty is 0
+      lipschitz_active <- lipschitz_active + 1e-8
+
+      lipschitz_active <- Rmlx::mlx_reshape(
+        Rmlx::as_mlx(lipschitz_active),
+        c(length(active_idx), 1)
       )
 
-      # Extract results
-      beta_mlx[active_idx, ] <- result$beta_new
-      intercept_mlx <- result$intercept_new
-      eta_mlx <- result$eta_new
-      residual_mlx <- result$residual_new
-
-      # Convergence check using MLX operations
-      if (iter %% 10 == 0 || iter == maxit) {
-        # Batch convergence checks to cut reduction/transfer overhead
-        delta_beta_max <- as.numeric(max(abs(result$delta_beta)))
-        intercept_delta_abs <- as.numeric(abs(result$intercept_delta))
-        if (delta_beta_max < tol && intercept_delta_abs < tol) break
+      block_size_active <- max(
+        1L,
+        min(as.integer(block_size), length(active_idx))
+      )
+      if (block_size_active > 1L && family_name == "gaussian") {
+        block_indices <- split(
+          seq_len(length(active_idx)),
+          ceiling(seq_len(length(active_idx)) / block_size_active)
+        )
+        for (blk in block_indices) {
+          if (length(blk) <= 1L) {
+            next
+          }
+          x_block <- x_active_mlx[, blk, drop = FALSE]
+          gram <- crossprod(x_block, x_block) / n_obs
+          if (ridge_penalty > 0) {
+            eye_blk <- Rmlx::mlx_eye(
+              length(blk),
+              dtype = gram$dtype,
+              device = gram$device
+            )
+            gram <- gram + ridge_penalty * eye_blk
+          }
+          svd_vals <- Rmlx::svd(gram, nu = 0, nv = 0)
+          spectral <- max(as.numeric(svd_vals$d))
+          diag_vals <- as.numeric(lipschitz_active[blk, , drop = FALSE])
+          diag_max <- max(diag_vals)
+          if (spectral > diag_max && diag_max > 0) {
+            scale <- spectral / diag_max
+            lipschitz_active[blk, ] <- lipschitz_active[blk, ] * scale
+          }
+        }
+      } else {
+        block_size_active <- 1L
       }
+
+      grad_cache <- NULL
+      if (family_name == "gaussian") {
+        grad_cache <- new.env(parent = emptyenv())
+        grad_cache$type <- "gaussian"
+        grad_cache$x <- x_active_mlx
+        grad_cache$n_obs <- n_obs
+        grad_cache$ridge_penalty <- ridge_penalty
+        grad_cache$residual <- y_mlx -
+          (x_active_mlx %*% beta_active_mlx + ones_mlx * intercept_mlx)
+      } else if (family_name %in% c("binomial", "quasibinomial")) {
+        grad_cache <- new.env(parent = emptyenv())
+        grad_cache$type <- "binomial"
+        grad_cache$x <- x_active_mlx
+        grad_cache$n_obs <- n_obs
+        grad_cache$ridge_penalty <- ridge_penalty
+        grad_cache$y <- y_mlx
+        grad_cache$eta <- x_active_mlx %*%
+          beta_active_mlx +
+          ones_mlx * intercept_mlx
+        grad_cache$mu <- 1 / (1 + exp(-grad_cache$eta))
+        grad_cache$residual <- grad_cache$mu - y_mlx
+      }
+
+      # Run coordinate descent (let it handle compilation internally)
+
+      result <- Rmlx::mlx_coordinate_descent(
+        loss_fn = loss_active,
+        beta_init = beta_active_mlx,
+        lambda = l1_penalty,
+        grad_fn = grad_active,
+        lipschitz = lipschitz_active,
+        max_iter = maxit,
+        tol = tol,
+        block_size = block_size_active,
+        grad_cache = grad_cache
+      )
+
+      # Check for NaN in result
+      result_beta_vec <- as.numeric(result$beta)
+      if (any(is.nan(result_beta_vec))) {
+        warning(sprintf(
+          "Coordinate descent produced NaN at lambda index %d (lambda=%.6f, converged=%s, iterations=%d)",
+          idx,
+          lambda_val,
+          result$converged,
+          result$iterations
+        ))
+      }
+
+      # Expand beta back to full size (if all active, this is a no-op)
+      beta_mlx <- Rmlx::mlx_zeros(c(n_pred, 1))
+      beta_mlx[active_idx, ] <- result$beta
+
+      # Update intercept
+      if (intercept) {
+        if (family_name == "gaussian") {
+          residual_mlx <- y_mlx - x_std_mlx %*% beta_mlx
+          intercept_mlx <- sum(residual_mlx) / n_obs
+        } else if (family_name %in% c("binomial", "quasibinomial")) {
+          for (intercept_iter in seq_len(2)) {
+            eta <- x_std_mlx %*% beta_mlx + ones_mlx * intercept_mlx
+            mu <- 1 / (1 + exp(-eta))
+            residual <- mu - y_mlx
+            w <- mu * (1 - mu)
+            grad_intercept <- sum(residual) / n_obs
+            hess_intercept <- sum(w) / n_obs
+            intercept_new <- intercept_mlx -
+              grad_intercept / (hess_intercept + 1e-8)
+            if (as.logical(abs(intercept_new - intercept_mlx) < tol)) {
+              intercept_mlx <- intercept_new
+              break
+            }
+            intercept_mlx <- intercept_new
+          }
+        }
+      } else {
+        intercept_mlx <- Rmlx::as_mlx(0)
+      }
+
+      # Check KKT conditions if strong rules were used and some predictors were screened out
+      if (!use_strong_rules || sum(active_set) == n_pred) {
+        break # No screening, so no KKT check needed
+      }
+
+      # Compute gradient for all predictors
+      eta_mlx <- x_std_mlx %*% beta_mlx + ones_mlx * intercept_mlx
+      if (family_name == "gaussian") {
+        residual_full <- y_mlx - eta_mlx
+        grad_full <- -crossprod(x_std_mlx, residual_full) / n_obs
+      } else {
+        mu <- 1 / (1 + exp(-eta_mlx))
+        residual_full <- mu - y_mlx
+        grad_full <- crossprod(x_std_mlx, residual_full) / n_obs
+      }
+      grad_full <- grad_full + ridge_penalty * beta_mlx
+
+      # Check KKT violations for inactive predictors
+      inactive_mask <- !active_mask
+      kkt_threshold <- l1_penalty + tol
+      violations_mask <- inactive_mask & (abs(grad_full) > kkt_threshold)
+      violations <- as.logical(violations_mask)
+
+      # Handle NAs (treat as no violation to be safe)
+      violations[is.na(violations)] <- FALSE
+
+      if (!any(violations, na.rm = TRUE)) {
+        break # No violations, we're done
+      }
+
+      # Add violators to active set and refit
+      active_set <- active_set | violations
+      active_mask <- active_mask | violations_mask
     }
 
-    # Store in MLX - no conversion until the end
+    # Store results
     beta_store_mlx[, idx] <- beta_mlx
     intercept_store_mlx[idx, ] <- intercept_mlx
 
-    grad_prev_mlx <- crossprod(x_std_mlx, residual_mlx) / n_obs
+    # Force evaluation at each lambda (outer loop iteration)
+    # See: https://ml-explore.github.io/mlx/build/html/usage/lazy_evaluation.html
+    Rmlx::mlx_eval(beta_mlx)
+    Rmlx::mlx_eval(intercept_mlx)
+
+    # Update for strong rules (future optimization)
+    eta_mlx <- x_std_mlx %*% beta_mlx + ones_mlx * intercept_mlx
+    residual_mlx <- y_mlx - eta_mlx
+    grad_prev <- crossprod(x_std_mlx, residual_mlx) / n_obs
     lambda_prev <- lambda_val
   }
 
   if (standardize) {
     beta_unscaled <- beta_store_mlx / x_scale
     intercept_adjustment <- Rmlx::colSums(beta_unscaled * x_center)
-    intercept_adjustment <- Rmlx::mlx_reshape(intercept_adjustment, c(n_lambda, 1))
+    intercept_adjustment <- Rmlx::mlx_reshape(
+      intercept_adjustment,
+      c(n_lambda, 1)
+    )
     intercept_unscaled <- intercept_store_mlx - intercept_adjustment
   } else {
     beta_unscaled <- beta_store_mlx
     intercept_unscaled <- intercept_store_mlx
   }
-  
-  # Convert to R only once at the very end
-  beta_unscaled <- as.matrix(beta_unscaled)
-  intercept_unscaled <- as.numeric(intercept_unscaled)
 
-  rownames(beta_unscaled) <- colnames(x)
   result <- list(
     a0 = intercept_unscaled,
     beta = beta_unscaled,
-    lambda = lambda,
+    lambda = Rmlx::as_mlx(lambda),
+    lambda_numeric = lambda,
     alpha = alpha,
     family = family_name,
     standardize = standardize,
     intercept = intercept,
     x_center = x_center,
     x_scale = x_scale,
+    coef_names = colnames(x),
     call = match.call()
   )
 

--- a/R/mlxs-glmnet.R
+++ b/R/mlxs-glmnet.R
@@ -4,9 +4,9 @@
 #' the heavy linear algebra. Currently supports Gaussian and binomial families
 #' with an optional intercept and column standardisation.
 #'
-#' @note This function is early work. It is currently only faster than
-#'   [glmnet::glmnet()] for very large data: roughly 100,000 observations
-#'   and 1000 predictors.
+#' @note This function is a proof-of-concept. On large dense problems it is
+#'   typically several times slower than the highly optimised
+#'   [glmnet::glmnet()] implementation.
 #'
 #' @param x Numeric matrix of predictors (observations in rows).
 #' @param y Numeric response vector (for binomial, values must be 0/1).
@@ -24,43 +24,26 @@
 #' @param intercept Should an intercept be fit?
 #' @param maxit Maximum proximal-gradient iterations per lambda value.
 #' @param tol Convergence tolerance on the coefficient updates.
-#' @param use_strong_rules Should strong rules be used to screen out inactive
-#'   predictors? This can speed up fitting for sparse problems.
-#' @param block_size Number of coefficients to update per gradient evaluation.
-#'   Set to 1 for classic coordinate descent; larger values (e.g., 16-64) batch
-#'   updates for speed at the cost of a slightly more conservative step size.
-#' @return An object of class `mlxs_glmnet` containing MLX arrays for the
-#'   coefficient path (`beta`), intercepts (`a0`), and lambda sequence
-#'   (`lambda`). Use `as.matrix()` / `as.numeric()` or the provided print
-#'   method to materialise these on the host when needed.
+#' @return An object of class `mlxs_glmnet` containing the fitted coefficient
+#'   path, intercepts, lambda sequence, and scaling information.
 #' @export
-mlxs_glmnet <- function(
-  x,
-  y,
-  family = mlxs_gaussian(),
-  alpha = 1,
-  lambda = NULL,
-  nlambda = 100,
-  lambda_min_ratio = 1e-4,
-  standardize = TRUE,
-  intercept = TRUE,
-  maxit = 1000,
-  tol = 1e-6,
-  use_strong_rules = TRUE,
-  block_size = 16L
-) {
+mlxs_glmnet <- function(x,
+                        y,
+                        family = mlxs_gaussian(),
+                        alpha = 1,
+                        lambda = NULL,
+                        nlambda = 100,
+                        lambda_min_ratio = 1e-4,
+                        standardize = TRUE,
+                        intercept = TRUE,
+                        maxit = 1000,
+                        tol = 1e-6) {
   family_name <- family$family
   if (!family_name %in% c("gaussian", "binomial", "quasibinomial")) {
-    stop(
-      "mlxs_glmnet() currently supports gaussian and binomial families.",
-      call. = FALSE
-    )
+    stop("mlxs_glmnet() currently supports gaussian and binomial families.", call. = FALSE)
   }
   if (alpha <= 0) {
-    stop(
-      "alpha must be > 0 for the current MLX elastic-net implementation.",
-      call. = FALSE
-    )
+    stop("alpha must be > 0 for the current MLX elastic-net implementation.", call. = FALSE)
   }
 
   x <- as.matrix(x)
@@ -78,10 +61,7 @@ mlxs_glmnet <- function(
 
   if (standardize) {
     x_std_mlx <- scale(x_mlx)
-    x_center <- Rmlx::mlx_reshape(
-      attr(x_std_mlx, "scaled:center"),
-      c(n_pred, 1)
-    )
+    x_center <- Rmlx::mlx_reshape(attr(x_std_mlx, "scaled:center"), c(n_pred, 1))
     x_scale <- Rmlx::mlx_reshape(attr(x_std_mlx, "scaled:scale"), c(n_pred, 1))
   } else {
     x_std_mlx <- x_mlx
@@ -105,8 +85,8 @@ mlxs_glmnet <- function(
   mu0_mlx <- Rmlx::as_mlx(matrix(mu0, ncol = 1))
   residual0_mlx <- mu0_mlx - y_mlx
   z0_mlx <- crossprod(x_std_mlx, residual0_mlx) / n_obs
-  z0_vals <- as.numeric(z0_mlx)
-  lambda_max <- max(abs(z0_vals)) / max(alpha, 1e-8)
+  z0 <- as.numeric(z0_mlx)
+  lambda_max <- max(abs(z0)) / max(alpha, 1e-8)
   if (is.finite(lambda_max) && lambda_max == 0) {
     lambda_max <- 1
   }
@@ -126,309 +106,115 @@ mlxs_glmnet <- function(
   # Keep stores as MLX to avoid per-lambda conversions
   beta_store_mlx <- Rmlx::mlx_zeros(c(n_pred, n_lambda))
   intercept_store_mlx <- Rmlx::mlx_zeros(c(n_lambda, 1))
-  grad_prev <- z0_mlx
+  grad_prev <- z0
   lambda_prev <- lambda[1]
 
   col_sq_sums_mlx <- Rmlx::colSums(x_std_mlx^2)
   col_sq_sums <- as.numeric(col_sq_sums_mlx)
+  base_lipschitz <- max(col_sq_sums) / n_obs
+  if (family_name %in% c("binomial", "quasibinomial")) {
+    base_lipschitz <- 0.25 * base_lipschitz
+  }
+
+  # Tolerance as MLX scalar for comparisons
+  tol_mlx <- Rmlx::as_mlx(matrix(tol, nrow = 1, ncol = 1))
+
+  # Get compiled iteration function (caches on first call)
+  iter_func <- .get_compiled_iteration()
+
+  # Family flag for compiled function (1 = gaussian, 0 = binomial)
+  is_gaussian_flag <- Rmlx::as_mlx(matrix(
+    if (family_name == "gaussian") 1 else 0,
+    nrow = 1, ncol = 1
+  ))
 
   eta_mlx <- x_std_mlx %*% beta_mlx + ones_mlx * intercept_mlx
   mu_mlx <- family$linkinv(eta_mlx)
   residual_mlx <- mu_mlx - y_mlx
 
-  # Coordinate descent path
   for (idx in seq_along(lambda)) {
     lambda_val <- lambda[idx]
-
-    # Run coordinate descent for this lambda
-    ridge_penalty <- lambda_val * (1 - alpha)
-    l1_penalty <- lambda_val * alpha
-
-    # Apply strong rules screening
-    active_set <- rep(TRUE, n_pred)
-    if (use_strong_rules && idx > 1) {
-      grad_prev_host <- as.numeric(grad_prev)
-      # Strong rule: discard j if |grad_j(lambda_prev)| < alpha * (2*lambda_k - lambda_{k-1})
-      strong_threshold <- alpha * (2 * lambda_val - lambda_prev)
-      active_set <- abs(grad_prev_host) >= strong_threshold
-
-      # Handle NAs (treat as active to be safe)
-      active_set[is.na(active_set)] <- TRUE
-
-      # Always keep variables that were active at previous lambda
-      beta_prev_active <- abs(as.numeric(beta_mlx)) > 0
-      active_set <- active_set | beta_prev_active
-
-      # Ensure at least one predictor is active
-      if (!any(active_set, na.rm = TRUE)) {
-        active_set[which.max(abs(grad_prev_host))] <- TRUE
-      }
+    step <- 1 / (base_lipschitz + lambda_val * (1 - alpha))
+    if (!is.finite(step) || step <= 0) {
+      step <- 1e-3
     }
-    active_mask <- Rmlx::as_mlx(
-      matrix(as.integer(active_set), ncol = 1),
-      dtype = "bool"
-    )
 
-    # Fit with KKT checking loop
-    repeat {
-      active_set <- as.logical(active_mask)
-      # Subset to active predictors (if all active, this is the full set)
-      active_idx <- which(active_set)
-
-      # Debug: check for empty active set
+    if (idx == 1) {
+      active_idx <- seq_len(n_pred)
+    } else {
+      cutoff <- alpha * (2 * lambda_val - lambda_prev)
+      strong_set <- which(abs(grad_prev) > cutoff)
+      # Convert previous beta column to R only for strong rules check
+      beta_numeric <- as.numeric(beta_store_mlx[, idx - 1])
+      nonzero_set <- which(beta_numeric != 0)
+      active_idx <- sort(unique(c(strong_set, nonzero_set)))
       if (length(active_idx) == 0) {
-        stop(
-          "Empty active set at lambda index ",
-          idx,
-          ". This should not happen - strong rules logic has a bug."
-        )
+        active_idx <- which.max(abs(grad_prev))
       }
-
-      x_active_mlx <- x_std_mlx[, active_idx, drop = FALSE]
-      beta_active_mlx <- beta_mlx[active_idx, , drop = FALSE]
-      col_sq_sums_active <- col_sq_sums[active_idx]
-
-      # Define loss and gradient on active set
-      if (family_name == "gaussian") {
-        loss_active <- function(beta) {
-          eta <- x_active_mlx %*% beta + ones_mlx * intercept_mlx
-          loss_smooth <- Rmlx::mlx_mse_loss(eta, y_mlx, reduction = "mean")
-          loss_smooth <- loss_smooth + 0.5 * ridge_penalty * sum(beta^2)
-          loss_smooth
-        }
-        grad_active <- function(beta) {
-          eta <- x_active_mlx %*% beta + ones_mlx * intercept_mlx
-          residual <- y_mlx - eta
-          grad <- -crossprod(x_active_mlx, residual) / n_obs
-          grad <- grad + ridge_penalty * beta
-          grad
-        }
-      } else {
-        loss_active <- function(beta) {
-          eta <- x_active_mlx %*% beta + ones_mlx * intercept_mlx
-          mu <- 1 / (1 + exp(-eta))
-          loss_smooth <- Rmlx::mlx_binary_cross_entropy(
-            mu,
-            y_mlx,
-            reduction = "mean"
-          )
-          loss_smooth <- loss_smooth + 0.5 * ridge_penalty * sum(beta^2)
-          loss_smooth
-        }
-        grad_active <- function(beta) {
-          eta <- x_active_mlx %*% beta + ones_mlx * intercept_mlx
-          mu <- 1 / (1 + exp(-eta))
-          residual <- mu - y_mlx
-          grad <- crossprod(x_active_mlx, residual) / n_obs
-          grad <- grad + ridge_penalty * beta
-          grad
-        }
-      }
-
-      lipschitz_active <- col_sq_sums_active / n_obs + ridge_penalty
-      if (family_name %in% c("binomial", "quasibinomial")) {
-        lipschitz_active <- 0.25 * lipschitz_active
-      }
-
-      # Add small epsilon for numerical stability when ridge_penalty is 0
-      lipschitz_active <- lipschitz_active + 1e-8
-
-      lipschitz_active <- Rmlx::mlx_reshape(
-        Rmlx::as_mlx(lipschitz_active),
-        c(length(active_idx), 1)
-      )
-
-      block_size_active <- max(
-        1L,
-        min(as.integer(block_size), length(active_idx))
-      )
-      if (block_size_active > 1L && family_name == "gaussian") {
-        block_indices <- split(
-          seq_len(length(active_idx)),
-          ceiling(seq_len(length(active_idx)) / block_size_active)
-        )
-        for (blk in block_indices) {
-          if (length(blk) <= 1L) {
-            next
-          }
-          x_block <- x_active_mlx[, blk, drop = FALSE]
-          gram <- crossprod(x_block, x_block) / n_obs
-          if (ridge_penalty > 0) {
-            eye_blk <- Rmlx::mlx_eye(
-              length(blk),
-              dtype = gram$dtype,
-              device = gram$device
-            )
-            gram <- gram + ridge_penalty * eye_blk
-          }
-          svd_vals <- Rmlx::svd(gram, nu = 0, nv = 0)
-          spectral <- max(as.numeric(svd_vals$d))
-          diag_vals <- as.numeric(lipschitz_active[blk, , drop = FALSE])
-          diag_max <- max(diag_vals)
-          if (spectral > diag_max && diag_max > 0) {
-            scale <- spectral / diag_max
-            lipschitz_active[blk, ] <- lipschitz_active[blk, ] * scale
-          }
-        }
-      } else {
-        block_size_active <- 1L
-      }
-
-      grad_cache <- NULL
-      if (family_name == "gaussian") {
-        grad_cache <- new.env(parent = emptyenv())
-        grad_cache$type <- "gaussian"
-        grad_cache$x <- x_active_mlx
-        grad_cache$n_obs <- n_obs
-        grad_cache$ridge_penalty <- ridge_penalty
-        grad_cache$residual <- y_mlx -
-          (x_active_mlx %*% beta_active_mlx + ones_mlx * intercept_mlx)
-      } else if (family_name %in% c("binomial", "quasibinomial")) {
-        grad_cache <- new.env(parent = emptyenv())
-        grad_cache$type <- "binomial"
-        grad_cache$x <- x_active_mlx
-        grad_cache$n_obs <- n_obs
-        grad_cache$ridge_penalty <- ridge_penalty
-        grad_cache$y <- y_mlx
-        grad_cache$eta <- x_active_mlx %*%
-          beta_active_mlx +
-          ones_mlx * intercept_mlx
-        grad_cache$mu <- 1 / (1 + exp(-grad_cache$eta))
-        grad_cache$residual <- grad_cache$mu - y_mlx
-      }
-
-      # Run coordinate descent (let it handle compilation internally)
-
-      result <- Rmlx::mlx_coordinate_descent(
-        loss_fn = loss_active,
-        beta_init = beta_active_mlx,
-        lambda = l1_penalty,
-        grad_fn = grad_active,
-        lipschitz = lipschitz_active,
-        max_iter = maxit,
-        tol = tol,
-        block_size = block_size_active,
-        grad_cache = grad_cache
-      )
-
-      # Check for NaN in result
-      result_beta_vec <- as.numeric(result$beta)
-      if (any(is.nan(result_beta_vec))) {
-        warning(sprintf(
-          "Coordinate descent produced NaN at lambda index %d (lambda=%.6f, converged=%s, iterations=%d)",
-          idx,
-          lambda_val,
-          result$converged,
-          result$iterations
-        ))
-      }
-
-      # Expand beta back to full size (if all active, this is a no-op)
-      beta_mlx <- Rmlx::mlx_zeros(c(n_pred, 1))
-      beta_mlx[active_idx, ] <- result$beta
-
-      # Update intercept
-      if (intercept) {
-        if (family_name == "gaussian") {
-          residual_mlx <- y_mlx - x_std_mlx %*% beta_mlx
-          intercept_mlx <- sum(residual_mlx) / n_obs
-        } else if (family_name %in% c("binomial", "quasibinomial")) {
-          for (intercept_iter in seq_len(2)) {
-            eta <- x_std_mlx %*% beta_mlx + ones_mlx * intercept_mlx
-            mu <- 1 / (1 + exp(-eta))
-            residual <- mu - y_mlx
-            w <- mu * (1 - mu)
-            grad_intercept <- sum(residual) / n_obs
-            hess_intercept <- sum(w) / n_obs
-            intercept_new <- intercept_mlx -
-              grad_intercept / (hess_intercept + 1e-8)
-            if (as.logical(abs(intercept_new - intercept_mlx) < tol)) {
-              intercept_mlx <- intercept_new
-              break
-            }
-            intercept_mlx <- intercept_new
-          }
-        }
-      } else {
-        intercept_mlx <- Rmlx::as_mlx(0)
-      }
-
-      # Check KKT conditions if strong rules were used and some predictors were screened out
-      if (!use_strong_rules || sum(active_set) == n_pred) {
-        break # No screening, so no KKT check needed
-      }
-
-      # Compute gradient for all predictors
-      eta_mlx <- x_std_mlx %*% beta_mlx + ones_mlx * intercept_mlx
-      if (family_name == "gaussian") {
-        residual_full <- y_mlx - eta_mlx
-        grad_full <- -crossprod(x_std_mlx, residual_full) / n_obs
-      } else {
-        mu <- 1 / (1 + exp(-eta_mlx))
-        residual_full <- mu - y_mlx
-        grad_full <- crossprod(x_std_mlx, residual_full) / n_obs
-      }
-      grad_full <- grad_full + ridge_penalty * beta_mlx
-
-      # Check KKT violations for inactive predictors
-      inactive_mask <- !active_mask
-      kkt_threshold <- l1_penalty + tol
-      violations_mask <- inactive_mask & (abs(grad_full) > kkt_threshold)
-      violations <- as.logical(violations_mask)
-
-      # Handle NAs (treat as no violation to be safe)
-      violations[is.na(violations)] <- FALSE
-
-      if (!any(violations, na.rm = TRUE)) {
-        break # No violations, we're done
-      }
-
-      # Add violators to active set and refit
-      active_set <- active_set | violations
-      active_mask <- active_mask | violations_mask
     }
 
-    # Store results
+    # Precompute threshold for compiled function
+    thresh <- lambda_val * alpha * step
+
+    for (iter in seq_len(maxit)) {
+      x_active <- x_std_mlx[, active_idx, drop = FALSE]
+      beta_prev_subset <- beta_mlx[active_idx, , drop = FALSE]
+
+      # Call compiled iteration function
+      result <- iter_func(
+        x_active, beta_prev_subset, residual_mlx,
+        intercept_mlx, eta_mlx, y_mlx, ones_mlx,
+        n_obs, step, lambda_val, alpha, thresh,
+        is_gaussian_flag
+      )
+
+      # Extract results
+      beta_mlx[active_idx, ] <- result$beta_new
+      intercept_mlx <- result$intercept_new
+      eta_mlx <- result$eta_new
+      residual_mlx <- result$residual_new
+
+      # Convergence check using MLX operations
+      delta_beta_max <- max(abs(result$delta_beta))
+      intercept_delta_abs <- abs(result$intercept_delta)
+      if (as.logical(delta_beta_max < tol) && as.logical(intercept_delta_abs < tol)) {
+        break
+      }
+    }
+
+    # Store in MLX - no conversion until the end
     beta_store_mlx[, idx] <- beta_mlx
     intercept_store_mlx[idx, ] <- intercept_mlx
 
-    # Force evaluation at each lambda (outer loop iteration)
-    # See: https://ml-explore.github.io/mlx/build/html/usage/lazy_evaluation.html
-    Rmlx::mlx_eval(beta_mlx)
-    Rmlx::mlx_eval(intercept_mlx)
-
-    # Update for strong rules (future optimization)
-    eta_mlx <- x_std_mlx %*% beta_mlx + ones_mlx * intercept_mlx
-    residual_mlx <- y_mlx - eta_mlx
-    grad_prev <- crossprod(x_std_mlx, residual_mlx) / n_obs
+    grad_prev <- as.numeric(crossprod(x_std_mlx, residual_mlx) / n_obs)
     lambda_prev <- lambda_val
   }
 
   if (standardize) {
     beta_unscaled <- beta_store_mlx / x_scale
     intercept_adjustment <- Rmlx::colSums(beta_unscaled * x_center)
-    intercept_adjustment <- Rmlx::mlx_reshape(
-      intercept_adjustment,
-      c(n_lambda, 1)
-    )
+    intercept_adjustment <- Rmlx::mlx_reshape(intercept_adjustment, c(n_lambda, 1))
     intercept_unscaled <- intercept_store_mlx - intercept_adjustment
   } else {
     beta_unscaled <- beta_store_mlx
     intercept_unscaled <- intercept_store_mlx
   }
+  
+  # Convert to R only once at the very end
+  beta_unscaled <- as.matrix(beta_unscaled)
+  intercept_unscaled <- as.numeric(intercept_unscaled)
 
+  rownames(beta_unscaled) <- colnames(x)
   result <- list(
     a0 = intercept_unscaled,
     beta = beta_unscaled,
-    lambda = Rmlx::as_mlx(lambda),
-    lambda_numeric = lambda,
+    lambda = lambda,
     alpha = alpha,
     family = family_name,
     standardize = standardize,
     intercept = intercept,
     x_center = x_center,
     x_scale = x_scale,
-    coef_names = colnames(x),
     call = match.call()
   )
 

--- a/R/mlxs-glmnet.R
+++ b/R/mlxs-glmnet.R
@@ -1,12 +1,12 @@
 #' MLX-backed elastic net regression
 #'
-#' Fit lasso or elastic-net penalised regression paths using MLX tensors for
-#' the heavy linear algebra. Currently supports Gaussian and binomial families
-#' with an optional intercept and column standardisation.
+#' Fit lasso or elastic-net penalised regression paths using MLX arrays for the
+#' heavy linear algebra. Dense Gaussian and binomial paths stay on the MLX
+#' backend throughout the iterative updates.
 #'
-#' @note This function is a proof-of-concept. On large dense problems it is
-#'   typically several times slower than the highly optimised
-#'   [glmnet::glmnet()] implementation.
+#' @note This implementation uses dense MLX updates rather than `glmnet`'s
+#'   coordinate-descent Fortran kernels, so `glmnet::glmnet()` can still be
+#'   faster on smaller problems.
 #'
 #' @param x Numeric matrix of predictors (observations in rows).
 #' @param y Numeric response vector (for binomial, values must be 0/1).
@@ -19,9 +19,11 @@
 #'   `lambda_max * lambda_min_ratio`.
 #' @param nlambda Length of automatically generated lambda path.
 #' @param lambda_min_ratio Smallest lambda as a fraction of `lambda_max`.
-#' @param standardize Should columns of `x` be centred and scaled before
-#'   fitting? Coefficients are returned on the original scale regardless.
+#' @param standardize Should columns of `x` be scaled before fitting?
 #' @param intercept Should an intercept be fit?
+#' @param use_strong_rules Retained for API compatibility. The dense MLX solver
+#'   keeps all coefficients on device, so this flag currently does not change
+#'   the computation.
 #' @param maxit Maximum proximal-gradient iterations per lambda value.
 #' @param tol Convergence tolerance on the coefficient updates.
 #' @return An object of class `mlxs_glmnet` containing the fitted coefficient
@@ -36,14 +38,17 @@ mlxs_glmnet <- function(x,
                         lambda_min_ratio = 1e-4,
                         standardize = TRUE,
                         intercept = TRUE,
+                        use_strong_rules = TRUE,
                         maxit = 1000,
                         tol = 1e-6) {
   family_name <- family$family
   if (!family_name %in% c("gaussian", "binomial", "quasibinomial")) {
-    stop("mlxs_glmnet() currently supports gaussian and binomial families.", call. = FALSE)
+    stop("mlxs_glmnet() currently supports gaussian and binomial families.",
+         call. = FALSE)
   }
   if (alpha <= 0) {
-    stop("alpha must be > 0 for the current MLX elastic-net implementation.", call. = FALSE)
+    stop("alpha must be > 0 for the current MLX elastic-net implementation.",
+         call. = FALSE)
   }
 
   x <- as.matrix(x)
@@ -54,165 +59,68 @@ mlxs_glmnet <- function(x,
 
   n_obs <- nrow(x)
   n_pred <- ncol(x)
+  chunk_size <- 8L
 
-  # Convert to MLX early
-  x_mlx <- Rmlx::as_mlx(x)
-  y_mlx <- Rmlx::mlx_reshape(Rmlx::as_mlx(y), c(n_obs, 1))
+  design <- .mlxs_glmnet_prepare_design(x, standardize = standardize,
+                                        intercept = intercept)
+  x_mlx <- design$x
+  x_center <- design$x_center
+  x_scale <- design$x_scale
 
-  if (standardize) {
-    x_std_mlx <- scale(x_mlx)
-    x_center <- Rmlx::mlx_reshape(attr(x_std_mlx, "scaled:center"), c(n_pred, 1))
-    x_scale <- Rmlx::mlx_reshape(attr(x_std_mlx, "scaled:scale"), c(n_pred, 1))
+  if (family_name == "gaussian") {
+    fit <- .mlxs_glmnet_fit_gaussian(
+      x_mlx = x_mlx,
+      y = y,
+      alpha = alpha,
+      lambda = lambda,
+      nlambda = nlambda,
+      lambda_min_ratio = lambda_min_ratio,
+      maxit = maxit,
+      tol = tol,
+      chunk_size = chunk_size
+    )
   } else {
-    x_std_mlx <- x_mlx
-    x_center <- Rmlx::mlx_zeros(c(n_pred, 1))
-    x_scale <- Rmlx::mlx_ones(c(n_pred, 1))
+    fit <- .mlxs_glmnet_fit_binomial(
+      x_mlx = x_mlx,
+      y = y,
+      alpha = alpha,
+      lambda = lambda,
+      nlambda = nlambda,
+      lambda_min_ratio = lambda_min_ratio,
+      intercept = intercept,
+      maxit = maxit,
+      tol = tol,
+      chunk_size = chunk_size
+    )
   }
 
-  if (family_name %in% c("binomial", "quasibinomial")) {
-    if (!all(y %in% c(0, 1))) {
-      stop("Binomial family requires a 0/1 response.", call. = FALSE)
-    }
-    p_hat <- mean(y)
-    p_hat <- min(max(p_hat, 1e-6), 1 - 1e-6)
-    intercept_val <- if (intercept) log(p_hat / (1 - p_hat)) else 0
-    mu0 <- rep(p_hat, n_obs)
+  n_lambda <- length(fit$lambda)
+  beta_store_mlx <- fit$beta
+  intercept_store_mlx <- fit$intercept
+
+  beta_unscaled_mlx <- beta_store_mlx / x_scale
+  if (intercept) {
+    intercept_adjustment <- Rmlx::colSums(beta_unscaled_mlx * x_center)
+    intercept_adjustment <- Rmlx::mlx_reshape(intercept_adjustment,
+                                              c(n_lambda, 1L))
+    intercept_unscaled_mlx <- intercept_store_mlx - intercept_adjustment
   } else {
-    intercept_val <- if (intercept) mean(y) else 0
-    mu0 <- rep(intercept_val, n_obs)
+    intercept_unscaled_mlx <- intercept_store_mlx
   }
 
-  mu0_mlx <- Rmlx::as_mlx(matrix(mu0, ncol = 1))
-  residual0_mlx <- mu0_mlx - y_mlx
-  z0_mlx <- crossprod(x_std_mlx, residual0_mlx) / n_obs
-  z0 <- as.numeric(z0_mlx)
-  lambda_max <- max(abs(z0)) / max(alpha, 1e-8)
-  if (is.finite(lambda_max) && lambda_max == 0) {
-    lambda_max <- 1
-  }
-
-  if (is.null(lambda)) {
-    lambda_min <- lambda_max * lambda_min_ratio
-    lambda <- exp(seq(log(lambda_max), log(lambda_min), length.out = nlambda))
-  } else {
-    lambda <- sort(as.numeric(lambda), decreasing = TRUE)
-  }
-  n_lambda <- length(lambda)
-
-  ones_mlx <- Rmlx::as_mlx(matrix(1, nrow = n_obs, ncol = 1))
-  beta_mlx <- Rmlx::mlx_zeros(c(n_pred, 1))
-  intercept_mlx <- Rmlx::as_mlx(matrix(intercept_val, nrow = 1, ncol = 1))
-
-  # Keep stores as MLX to avoid per-lambda conversions
-  beta_store_mlx <- Rmlx::mlx_zeros(c(n_pred, n_lambda))
-  intercept_store_mlx <- Rmlx::mlx_zeros(c(n_lambda, 1))
-  grad_prev <- z0
-  lambda_prev <- lambda[1]
-
-  col_sq_sums_mlx <- Rmlx::colSums(x_std_mlx^2)
-  col_sq_sums <- as.numeric(col_sq_sums_mlx)
-  base_lipschitz <- max(col_sq_sums) / n_obs
-  if (family_name %in% c("binomial", "quasibinomial")) {
-    base_lipschitz <- 0.25 * base_lipschitz
-  }
-
-  # Tolerance as MLX scalar for comparisons
-  tol_mlx <- Rmlx::as_mlx(matrix(tol, nrow = 1, ncol = 1))
-
-  # Get compiled iteration function (caches on first call)
-  iter_func <- .get_compiled_iteration()
-
-  # Family flag for compiled function (1 = gaussian, 0 = binomial)
-  is_gaussian_flag <- Rmlx::as_mlx(matrix(
-    if (family_name == "gaussian") 1 else 0,
-    nrow = 1, ncol = 1
-  ))
-
-  eta_mlx <- x_std_mlx %*% beta_mlx + ones_mlx * intercept_mlx
-  mu_mlx <- family$linkinv(eta_mlx)
-  residual_mlx <- mu_mlx - y_mlx
-
-  for (idx in seq_along(lambda)) {
-    lambda_val <- lambda[idx]
-    step <- 1 / (base_lipschitz + lambda_val * (1 - alpha))
-    if (!is.finite(step) || step <= 0) {
-      step <- 1e-3
-    }
-
-    if (idx == 1) {
-      active_idx <- seq_len(n_pred)
-    } else {
-      cutoff <- alpha * (2 * lambda_val - lambda_prev)
-      strong_set <- which(abs(grad_prev) > cutoff)
-      # Convert previous beta column to R only for strong rules check
-      beta_numeric <- as.numeric(beta_store_mlx[, idx - 1])
-      nonzero_set <- which(beta_numeric != 0)
-      active_idx <- sort(unique(c(strong_set, nonzero_set)))
-      if (length(active_idx) == 0) {
-        active_idx <- which.max(abs(grad_prev))
-      }
-    }
-
-    # Precompute threshold for compiled function
-    thresh <- lambda_val * alpha * step
-
-    for (iter in seq_len(maxit)) {
-      x_active <- x_std_mlx[, active_idx, drop = FALSE]
-      beta_prev_subset <- beta_mlx[active_idx, , drop = FALSE]
-
-      # Call compiled iteration function
-      result <- iter_func(
-        x_active, beta_prev_subset, residual_mlx,
-        intercept_mlx, eta_mlx, y_mlx, ones_mlx,
-        n_obs, step, lambda_val, alpha, thresh,
-        is_gaussian_flag
-      )
-
-      # Extract results
-      beta_mlx[active_idx, ] <- result$beta_new
-      intercept_mlx <- result$intercept_new
-      eta_mlx <- result$eta_new
-      residual_mlx <- result$residual_new
-
-      # Convergence check using MLX operations
-      delta_beta_max <- max(abs(result$delta_beta))
-      intercept_delta_abs <- abs(result$intercept_delta)
-      if (as.logical(delta_beta_max < tol) && as.logical(intercept_delta_abs < tol)) {
-        break
-      }
-    }
-
-    # Store in MLX - no conversion until the end
-    beta_store_mlx[, idx] <- beta_mlx
-    intercept_store_mlx[idx, ] <- intercept_mlx
-
-    grad_prev <- as.numeric(crossprod(x_std_mlx, residual_mlx) / n_obs)
-    lambda_prev <- lambda_val
-  }
-
-  if (standardize) {
-    beta_unscaled <- beta_store_mlx / x_scale
-    intercept_adjustment <- Rmlx::colSums(beta_unscaled * x_center)
-    intercept_adjustment <- Rmlx::mlx_reshape(intercept_adjustment, c(n_lambda, 1))
-    intercept_unscaled <- intercept_store_mlx - intercept_adjustment
-  } else {
-    beta_unscaled <- beta_store_mlx
-    intercept_unscaled <- intercept_store_mlx
-  }
-  
-  # Convert to R only once at the very end
-  beta_unscaled <- as.matrix(beta_unscaled)
-  intercept_unscaled <- as.numeric(intercept_unscaled)
+  beta_unscaled <- as.matrix(beta_unscaled_mlx)
+  intercept_unscaled <- as.numeric(intercept_unscaled_mlx)
 
   rownames(beta_unscaled) <- colnames(x)
   result <- list(
     a0 = intercept_unscaled,
     beta = beta_unscaled,
-    lambda = lambda,
+    lambda = fit$lambda,
     alpha = alpha,
     family = family_name,
     standardize = standardize,
     intercept = intercept,
+    use_strong_rules = use_strong_rules,
     x_center = x_center,
     x_scale = x_scale,
     call = match.call()
@@ -222,12 +130,236 @@ mlxs_glmnet <- function(x,
   result
 }
 
+.mlxs_glmnet_prepare_design <- function(x,
+                                        standardize,
+                                        intercept) {
+  x_mlx <- Rmlx::as_mlx(x)
+  n_pred <- ncol(x)
+
+  if (standardize || intercept) {
+    x_proc <- scale(x_mlx, center = intercept, scale = standardize)
+    x_center <- attr(x_proc, "scaled:center")
+    x_scale <- attr(x_proc, "scaled:scale")
+  } else {
+    x_proc <- x_mlx
+    x_center <- NULL
+    x_scale <- NULL
+  }
+
+  if (is.null(x_center)) {
+    x_center <- Rmlx::mlx_zeros(c(1L, n_pred))
+  }
+  if (is.null(x_scale)) {
+    x_scale <- Rmlx::mlx_ones(c(1L, n_pred))
+  }
+
+  list(
+    x = x_proc,
+    x_center = Rmlx::mlx_reshape(x_center, c(n_pred, 1L)),
+    x_scale = Rmlx::mlx_reshape(x_scale, c(n_pred, 1L))
+  )
+}
+
+.mlxs_glmnet_fit_gaussian <- function(x_mlx,
+                                      y,
+                                      alpha,
+                                      lambda,
+                                      nlambda,
+                                      lambda_min_ratio,
+                                      maxit,
+                                      tol,
+                                      chunk_size) {
+  n_obs <- nrow(x_mlx)
+  n_pred <- ncol(x_mlx)
+  y_mean <- mean(y)
+  y_mlx <- Rmlx::mlx_reshape(Rmlx::as_mlx(y - y_mean), c(n_obs, 1L))
+
+  lambda_max <- .mlxs_glmnet_lambda_max(x_mlx, -y_mlx, n_obs, alpha)
+  lambda <- .mlxs_glmnet_lambda_path(lambda, lambda_max, nlambda,
+                                     lambda_min_ratio)
+  n_lambda <- length(lambda)
+
+  beta_mlx <- Rmlx::mlx_zeros(c(n_pred, 1L))
+  eta_mlx <- Rmlx::mlx_zeros(c(n_obs, 1L))
+  residual_mlx <- -y_mlx
+  beta_store_mlx <- Rmlx::mlx_zeros(c(n_pred, n_lambda))
+  intercept_store_mlx <- Rmlx::mlx_zeros(c(n_lambda, 1L))
+  y_mean_mlx <- Rmlx::mlx_matrix(y_mean, nrow = 1L, ncol = 1L)
+
+  col_sq_sums <- as.numeric(Rmlx::colSums(x_mlx^2))
+  base_lipschitz <- max(col_sq_sums) / n_obs
+
+  for (idx in seq_along(lambda)) {
+    lambda_val <- lambda[idx]
+    step <- 1 / (base_lipschitz + lambda_val * (1 - alpha))
+    thresh <- lambda_val * alpha * step
+    ridge_penalty <- lambda_val * (1 - alpha)
+
+    remaining <- maxit
+    while (remaining > 0L) {
+      n_steps <- min(chunk_size, remaining)
+      state <- .mlxs_glmnet_gaussian_chunk(
+        x_mlx = x_mlx,
+        beta_mlx = beta_mlx,
+        eta_mlx = eta_mlx,
+        residual_mlx = residual_mlx,
+        y_mlx = y_mlx,
+        n_obs = n_obs,
+        step = step,
+        thresh = thresh,
+        ridge_penalty = ridge_penalty,
+        n_steps = n_steps
+      )
+
+      beta_mlx <- state$beta
+      eta_mlx <- state$eta
+      residual_mlx <- state$residual
+      remaining <- remaining - n_steps
+
+      if (as.logical(state$delta_max < tol)) {
+        break
+      }
+    }
+
+    beta_store_mlx <- Rmlx::mlx_slice_update(
+      beta_store_mlx,
+      beta_mlx,
+      start = c(1L, idx),
+      stop = c(n_pred, idx)
+    )
+    intercept_store_mlx <- Rmlx::mlx_slice_update(
+      intercept_store_mlx,
+      y_mean_mlx,
+      start = c(idx, 1L),
+      stop = c(idx, 1L)
+    )
+  }
+
+  list(
+    beta = beta_store_mlx,
+    intercept = intercept_store_mlx,
+    lambda = lambda
+  )
+}
+
+.mlxs_glmnet_fit_binomial <- function(x_mlx,
+                                      y,
+                                      alpha,
+                                      lambda,
+                                      nlambda,
+                                      lambda_min_ratio,
+                                      intercept,
+                                      maxit,
+                                      tol,
+                                      chunk_size) {
+  if (!all(y %in% c(0, 1))) {
+    stop("Binomial family requires a 0/1 response.", call. = FALSE)
+  }
+
+  n_obs <- nrow(x_mlx)
+  n_pred <- ncol(x_mlx)
+  y_mlx <- Rmlx::mlx_reshape(Rmlx::as_mlx(y), c(n_obs, 1L))
+  ones_mlx <- Rmlx::mlx_ones(c(n_obs, 1L))
+
+  p_hat <- mean(y)
+  p_hat <- min(max(p_hat, 1e-6), 1 - 1e-6)
+  intercept_val <- if (intercept) log(p_hat / (1 - p_hat)) else 0
+  intercept_mlx <- Rmlx::mlx_matrix(intercept_val, nrow = 1L, ncol = 1L)
+  beta_mlx <- Rmlx::mlx_zeros(c(n_pred, 1L))
+  eta_mlx <- if (intercept) ones_mlx * intercept_mlx else {
+    Rmlx::mlx_zeros(c(n_obs, 1L))
+  }
+  residual_mlx <- (1 / (1 + exp(-eta_mlx))) - y_mlx
+
+  lambda_max <- .mlxs_glmnet_lambda_max(x_mlx, residual_mlx, n_obs, alpha)
+  lambda <- .mlxs_glmnet_lambda_path(lambda, lambda_max, nlambda,
+                                     lambda_min_ratio)
+  n_lambda <- length(lambda)
+
+  beta_store_mlx <- Rmlx::mlx_zeros(c(n_pred, n_lambda))
+  intercept_store_mlx <- Rmlx::mlx_zeros(c(n_lambda, 1L))
+  col_sq_sums <- as.numeric(Rmlx::colSums(x_mlx^2))
+  base_lipschitz <- 0.25 * max(col_sq_sums) / n_obs
+
+  for (idx in seq_along(lambda)) {
+    lambda_val <- lambda[idx]
+    step <- 1 / (base_lipschitz + lambda_val * (1 - alpha))
+    thresh <- lambda_val * alpha * step
+    ridge_penalty <- lambda_val * (1 - alpha)
+
+    remaining <- maxit
+    while (remaining > 0L) {
+      n_steps <- min(chunk_size, remaining)
+      state <- .mlxs_glmnet_binomial_chunk(
+        x_mlx = x_mlx,
+        beta_mlx = beta_mlx,
+        intercept_mlx = intercept_mlx,
+        eta_mlx = eta_mlx,
+        residual_mlx = residual_mlx,
+        y_mlx = y_mlx,
+        ones_mlx = ones_mlx,
+        n_obs = n_obs,
+        step = step,
+        thresh = thresh,
+        ridge_penalty = ridge_penalty,
+        n_steps = n_steps,
+        fit_intercept = intercept
+      )
+
+      beta_mlx <- state$beta
+      intercept_mlx <- state$intercept
+      eta_mlx <- state$eta
+      residual_mlx <- state$residual
+      remaining <- remaining - n_steps
+
+      if (as.logical(state$delta_max < tol) &&
+          as.logical(state$intercept_delta_max < tol)) {
+        break
+      }
+    }
+
+    beta_store_mlx <- Rmlx::mlx_slice_update(
+      beta_store_mlx,
+      beta_mlx,
+      start = c(1L, idx),
+      stop = c(n_pred, idx)
+    )
+    intercept_store_mlx <- Rmlx::mlx_slice_update(
+      intercept_store_mlx,
+      intercept_mlx,
+      start = c(idx, 1L),
+      stop = c(idx, 1L)
+    )
+  }
+
+  list(
+    beta = beta_store_mlx,
+    intercept = intercept_store_mlx,
+    lambda = lambda
+  )
+}
+
+.mlxs_glmnet_lambda_max <- function(x_mlx, residual_mlx, n_obs, alpha) {
+  z0_mlx <- crossprod(x_mlx, residual_mlx) / n_obs
+  lambda_max <- max(abs(as.numeric(z0_mlx))) / max(alpha, 1e-8)
+  if (is.finite(lambda_max) && lambda_max == 0) {
+    lambda_max <- 1
+  }
+  lambda_max
+}
+
+.mlxs_glmnet_lambda_path <- function(lambda,
+                                     lambda_max,
+                                     nlambda,
+                                     lambda_min_ratio) {
+  if (is.null(lambda)) {
+    lambda_min <- lambda_max * lambda_min_ratio
+    exp(seq(log(lambda_max), log(lambda_min), length.out = nlambda))
+  } else {
+    sort(as.numeric(lambda), decreasing = TRUE)
+  }
+}
+
 .mlxs_soft_threshold <- function(z, thresh) {
-  # Soft threshold: sign(z) * max(|z| - thresh, 0)
-  # Simplified to reduce temporary allocations
-  abs_z <- abs(z)
-  magnitude <- Rmlx::mlx_maximum(abs_z - thresh, 0)
-  # Compute sign as z / |z|, with small epsilon to avoid division by zero
-  sign_z <- z / (abs_z + 1e-10)
-  magnitude * sign_z
+  sign(z) * Rmlx::mlx_maximum(abs(z) - thresh, 0)
 }

--- a/_pkgdown.yml
+++ b/_pkgdown.yml
@@ -6,3 +6,23 @@ reference:
     contents:
       - mlxs_lm
       - mlxs_lm_fit
+      - mlxs_lm_methods
+  - title: Generalized Linear Models
+    contents:
+      - mlxs_glm
+      - mlxs_glm_methods
+  - title: Elastic Net Models
+    contents:
+      - mlxs_glmnet
+  - title: Bootstrapping
+    contents:
+      - mlxs_boot
+  - title: Family Functions
+    contents:
+      - mlxs_gaussian
+      - mlxs_binomial
+      - mlxs_poisson
+      - mlxs_quasibinomial
+      - mlxs_quasipoisson
+      - generics-reexports
+      

--- a/man/mlxs_glmnet.Rd
+++ b/man/mlxs_glmnet.Rd
@@ -62,5 +62,7 @@ backend throughout the iterative updates.
 \note{
 This implementation uses dense MLX updates rather than \code{glmnet}'s
 coordinate-descent Fortran kernels, so \code{glmnet::glmnet()} can still be
-faster on smaller problems.
+faster on smaller problems. For very tall Gaussian problems, the fitter
+switches to a covariance-space MLX solver to reduce repeated \verb{X'X}
+products along the path.
 }

--- a/man/mlxs_glmnet.Rd
+++ b/man/mlxs_glmnet.Rd
@@ -14,10 +14,9 @@ mlxs_glmnet(
   lambda_min_ratio = 1e-04,
   standardize = TRUE,
   intercept = TRUE,
-  maxit = 1000,
-  tol = 1e-06,
   use_strong_rules = TRUE,
-  block_size = 16L
+  maxit = 1000,
+  tol = 1e-06
 )
 }
 \arguments{
@@ -39,35 +38,29 @@ a sequence of length \code{nlambda} is generated from \code{lambda_max} down to
 
 \item{lambda_min_ratio}{Smallest lambda as a fraction of \code{lambda_max}.}
 
-\item{standardize}{Should columns of \code{x} be centred and scaled before
-fitting? Coefficients are returned on the original scale regardless.}
+\item{standardize}{Should columns of \code{x} be scaled before fitting?}
 
 \item{intercept}{Should an intercept be fit?}
+
+\item{use_strong_rules}{Retained for API compatibility. The dense MLX solver
+keeps all coefficients on device, so this flag currently does not change
+the computation.}
 
 \item{maxit}{Maximum proximal-gradient iterations per lambda value.}
 
 \item{tol}{Convergence tolerance on the coefficient updates.}
-
-\item{use_strong_rules}{Should strong rules be used to screen out inactive
-predictors? This can speed up fitting for sparse problems.}
-
-\item{block_size}{Number of coefficients to update per gradient evaluation.
-Set to 1 for classic coordinate descent; larger values (e.g., 16-64) batch
-updates for speed at the cost of a slightly more conservative step size.}
 }
 \value{
-An object of class \code{mlxs_glmnet} containing MLX arrays for the
-coefficient path (\code{beta}), intercepts (\code{a0}), and lambda sequence
-(\code{lambda}). Use \code{as.matrix()} / \code{as.numeric()} or the provided print
-method to materialise these on the host when needed.
+An object of class \code{mlxs_glmnet} containing the fitted coefficient
+path, intercepts, lambda sequence, and scaling information.
 }
 \description{
-Fit lasso or elastic-net penalised regression paths using MLX tensors for
-the heavy linear algebra. Currently supports Gaussian and binomial families
-with an optional intercept and column standardisation.
+Fit lasso or elastic-net penalised regression paths using MLX arrays for the
+heavy linear algebra. Dense Gaussian and binomial paths stay on the MLX
+backend throughout the iterative updates.
 }
 \note{
-This function is early work. It is currently only faster than
-\code{\link[glmnet:glmnet]{glmnet::glmnet()}} for very large data: roughly 100,000 observations
-and 1000 predictors.
+This implementation uses dense MLX updates rather than \code{glmnet}'s
+coordinate-descent Fortran kernels, so \code{glmnet::glmnet()} can still be
+faster on smaller problems.
 }

--- a/man/mlxs_glmnet.Rd
+++ b/man/mlxs_glmnet.Rd
@@ -57,7 +57,8 @@ path, intercepts, lambda sequence, and scaling information.
 \description{
 Fit lasso or elastic-net penalised regression paths using MLX arrays for the
 heavy linear algebra. Dense Gaussian and binomial paths stay on the MLX
-backend throughout the iterative updates.
+backend throughout the iterative updates, with repeated chunk updates traced
+through \code{\link[Rmlx:mlx_compile]{Rmlx::mlx_compile()}} to reduce host overhead.
 }
 \note{
 This implementation uses dense MLX updates rather than \code{glmnet}'s

--- a/tests/testthat/test-mlxs-glmnet.R
+++ b/tests/testthat/test-mlxs-glmnet.R
@@ -53,6 +53,38 @@ test_that("mlxs_glmnet works with standardize = FALSE", {
   expect_equal(as.numeric(fit$a0)[1], as.numeric(ref$a0), tolerance = 5e-2)
 })
 
+test_that("mlxs_glmnet matches glmnet for gaussian without intercept", {
+  set.seed(124)
+  n <- 120
+  p <- 12
+  x <- matrix(rnorm(n * p), nrow = n, ncol = p)
+  beta_true <- c(runif(4, -1, 1), rep(0, p - 4))
+  y <- drop(x %*% beta_true + rnorm(n, sd = 0.5))
+  lambda <- 0.15
+
+  ref <- glmnet::glmnet(
+    x, y,
+    family = "gaussian",
+    alpha = 1,
+    lambda = lambda,
+    standardize = TRUE,
+    intercept = FALSE
+  )
+  fit <- mlxs_glmnet(
+    x, y,
+    family = mlxs_gaussian(),
+    alpha = 1,
+    lambda = lambda,
+    standardize = TRUE,
+    intercept = FALSE,
+    maxit = 3000,
+    tol = 1e-6
+  )
+
+  expect_equal(as.matrix(fit$beta)[, 1], as.numeric(ref$beta), tolerance = 5e-2)
+  expect_equal(as.numeric(fit$a0)[1], as.numeric(ref$a0), tolerance = 5e-2)
+})
+
 test_that("strong rules produce identical results to non-screened for gaussian", {
   set.seed(456)
   n <- 100

--- a/vignettes/benchmarks.Rmd
+++ b/vignettes/benchmarks.Rmd
@@ -14,6 +14,10 @@ params:
 ---
 
 ```{r setup, include=FALSE, message=FALSE}
+
+# To update this (and the pkgdown website) run
+# pkgdown::deploy_to_branch()
+
 knitr::opts_chunk$set(
   collapse = TRUE,
   comment = "#>",
@@ -37,7 +41,7 @@ library(huxtable)
 We benchmark RmlxStats against base R and specialized fast fitting packages,
 across varying numbers of cases (`n`) and predictors (`p`).
 
-Benchmarking was run on an M1 Macbook Air.
+Benchmarking was run on an M2 Macbook Air.
 
 ## Data Generation
 
@@ -52,6 +56,12 @@ colnames(X) <- paste0("x", seq_len(p_max))
 
 beta_true <- rnorm(p_max, mean = 0, sd = 0.5)
 y_continuous <- drop(X %*% beta_true + rnorm(n_max, sd = 2))
+
+# only 1 in 10 predictors matter:
+X_sparse <- X[, seq(10, p_max, 10)]
+beta_true_sparse <- beta_true[seq(1, p_max, 10)]
+y_sparse <- drop(X_sparse %*% beta_true_sparse + rnorm(n_max, sd = 2))
+
 linpred <- drop(X %*% beta_true) / 5  
 prob <- 1 / (1 + exp(-linpred))
 y_binary <- rbinom(n_max, size = 1, prob = prob)
@@ -59,6 +69,7 @@ y_binary <- rbinom(n_max, size = 1, prob = prob)
 full_data <- data.frame(
   y_cont = y_continuous,
   y_bin = y_binary,
+  y_sparse = y_sparse,
   X
 )
 
@@ -81,7 +92,7 @@ bench_grid <- bench_grid[bench_grid$n > bench_grid$p, ]
 
 ```
 
-## Linear Model Benchmarks
+## `lm` Benchmarks
 
 ```{r lm-benchmarks}
 lm_results <- list()
@@ -110,14 +121,14 @@ for (i in seq_len(nrow(bench_grid))) {
 
   bm$n <- n
   bm$p <- p
-  bm$model_type <- "LM"
+  bm$model_type <- "lm"
   lm_results[[i]] <- bm
 }
 
 lm_df <- do.call(rbind, lm_results)
 ```
 
-## GLM Benchmarks
+## `glm` Benchmarks
 
 ```{r glm-benchmarks}
 glm_results <- list()
@@ -149,11 +160,42 @@ for (i in seq_len(nrow(bench_grid))) {
 
   bm$n <- n
   bm$p <- p
-  bm$model_type <- "GLM"
+  bm$model_type <- "glm"
   glm_results[[i]] <- bm
 }
 
 glm_df <- do.call(rbind, glm_results)
+```
+
+## `glmnet` Benchmarks
+
+
+```{r glmnet-benchmarks}
+glmnet_results <- list()
+
+for (i in seq_len(nrow(bench_grid))) {
+  n <- bench_grid$n[i]
+  p <- bench_grid$p[i]
+
+  xvars <- paste0("x", 1:p)
+  x <- full_data[1:n, xvars]
+  y <- full_data[1:n, "y_sparse"]
+
+  bm <- mark(
+    "glmnet::glmnet" = glmnet::glmnet(x, y, lambda = 1/1:50),
+    "RmlxStats::mlxs_glmnet" = mlxs_glmnet(x, y, lambda = 1/1:50),
+    iterations = 3,
+    check = FALSE,
+    filter_gc = FALSE
+  )
+
+  bm$n <- n
+  bm$p <- p
+  bm$model_type <- "glmnet"
+  glmnet_results[[i]] <- bm
+}
+
+glmnet_df <- do.call(rbind, glmnet_results)
 ```
 
 ## Bootstrap Benchmarks
@@ -223,7 +265,7 @@ boot_df <- do.call(rbind, boot_results)
 
 
 ```{r prepare-viz-data, include = FALSE}
-all_results <- rbind(lm_df, glm_df, boot_df)
+all_results <- rbind(lm_df, glm_df, glmnet_df, boot_df)
 
 all_results$method <- as.character(all_results$expression)
 all_results$median_sec <- as.numeric(all_results$median, units = "s")
@@ -261,6 +303,8 @@ lm_mlxs <- "RmlxStats::mlxs_lm"
 lm_base <- "stats::lm"
 glm_mlxs <- "RmlxStats::mlxs_glm"
 glm_base <- "stats::glm"
+glmnet_mlxs <- "RmlxStats::mlxs_glmnet"
+glmnet_base <- "glmnet::glmnet"
 boot_case_mlxs <- "mlxs_case"
 boot_case_base <- "boot_case"
 boot_resid_mlxs <- "mlxs_resid"
@@ -268,8 +312,9 @@ boot_resid_base <- "lmboot_resid"
 
 # Process each model type
 models <- list(
-  list(name = "lm", mlxs = lm_mlxs, base = lm_base, type = "LM"),
-  list(name = "glm", mlxs = glm_mlxs, base = glm_base, type = "GLM"),
+  list(name = "lm", mlxs = lm_mlxs, base = lm_base, type = "lm"),
+  list(name = "glm", mlxs = glm_mlxs, base = glm_base, type = "glm"),
+  list(name = "glmnet", mlxs = glmnet_mlxs, base = glmnet_base, type = "glmnet"),
   list(name = "boot_case", mlxs = boot_case_mlxs, base = boot_case_base, type = "Bootstrap"),
   list(name = "boot_resid", mlxs = boot_resid_mlxs, base = boot_resid_base, type = "Bootstrap")
 )
@@ -346,6 +391,7 @@ colnames(fastest_table) <- gsub("speedup\\.", "", colnames(fastest_table))
 rownames(base_table) <- c(
   "lm" = "Linear Model",
   "glm" = "Logistic Regression",
+  "glmnet" = "Elastic Net",
   "boot_case" = "Bootstrap (Case)",
   "boot_resid" = "Bootstrap (Residual)"
 )[rownames(base_table)]
@@ -353,6 +399,7 @@ rownames(base_table) <- c(
 rownames(fastest_table) <- c(
   "lm" = "Linear Model",
   "glm" = "Logistic Regression",
+  "glmnet" = "Elastic Net",
   "boot_case" = "Bootstrap (Case)",
   "boot_resid" = "Bootstrap (Residual)"
 )[rownames(fastest_table)]
@@ -412,18 +459,25 @@ plot_benchmark <- function(data, title, subtitle = "Lower is better. Scales vary
 }
 ```
 
-## Linear Models
+## `lm` Models
 
 ```{r plot-lm, echo = FALSE}
-lm_data <- subset(summary_results, model_type == "LM")
+lm_data <- subset(summary_results, model_type == "lm")
 plot_benchmark(lm_data, "Linear Model Benchmark: Time by Dataset Size")
 ```
 
-## GLM Models
+## `glm` Models
 
 ```{r plot-glm, echo = FALSE}
-glm_data <- subset(summary_results, model_type == "GLM")
+glm_data <- subset(summary_results, model_type == "glm")
 plot_benchmark(glm_data, "GLM Benchmark: Time by Dataset Size")
+```
+
+## `glmnet` Models
+
+```{r plot-glmnet, echo = FALSE}
+lm_data <- subset(summary_results, model_type == "glmnet")
+plot_benchmark(lm_data, "Elastic Net Benchmark: Time by Dataset Size")
 ```
 
 ## Bootstraps


### PR DESCRIPTION
## Summary
Reduce host overhead in `mlxs_glmnet()` by caching `mlx_compile()`'d chunk-update kernels for the iterative path solvers.

Implemented for:

- dense Gaussian chunks
- covariance/Gram Gaussian chunks
- binomial chunks

## Why
The previous implementation stayed on-device for the array math but still paid substantial R-side overhead by re-entering the chunk helper for every iterative block along the lambda path. Tracing those repeated chunk updates through MLX cuts that overhead materially.

## Impact
Observed warm-path timing improvements on representative Gaussian problems:

- `5000 x 200`, `nlambda = 20`: about `7.9x` slower than `glmnet` before, now about `2.8x`
- `5000 x 200`, `nlambda = 50`: about `19x` slower before, now about `6.5x`
- `20000 x 100`, `nlambda = 50`: about `16.2x` slower before, now about `3.7x`

Cold-start trace cost still exists, so the first call for a new shape remains noticeably slower than warm runs.

## Validation
- `R -q -e 'devtools::document()'`
- `R -q -e 'devtools::test()'`
- local timing checks against `glmnet::glmnet()` and against the prior uncompiled chunk path